### PR TITLE
Invites full reimplementation with unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,17 +52,18 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
-	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
+	golang.org/x/net v0.3.0 // indirect
+	golang.org/x/oauth2 v0.3.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0
 	github.com/jaevor/go-nanoid v1.3.0
+	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37
 )

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ cloud.google.com/go/compute v1.12.1/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x
 cloud.google.com/go/compute v1.13.0 h1:AYrLkB8NPdDRslNp4Jxmzrhdr03fUAIDbiGFjLWowoU=
 cloud.google.com/go/compute v1.13.0/go.mod h1:5aPTS0cUNMIc1CE546K+Th6weJUNQErARyZtRXDJ8GE=
 cloud.google.com/go/compute/metadata v0.1.0/go.mod h1:Z1VN+bulIf6bt4P/C37K4DyZYZEXYonfTBHHFPO/4UU=
+cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/compute/metadata v0.2.1/go.mod h1:jgHgmJd2RKBGzXqF5LR2EZMGxBkeanZ9wwa75XHJgOM=
 cloud.google.com/go/compute/metadata v0.2.2 h1:aWKAjYaBaOSrpKl57+jnS/3fJRQnxL7TvR/u1VVbt6k=
 cloud.google.com/go/compute/metadata v0.2.2/go.mod h1:jgHgmJd2RKBGzXqF5LR2EZMGxBkeanZ9wwa75XHJgOM=
@@ -223,6 +224,7 @@ cloud.google.com/go/longrunning v0.3.0 h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+
 cloud.google.com/go/longrunning v0.3.0/go.mod h1:qth9Y41RRSUE69rDcOn6DdK3HfQfsUI0YSmW3iIlLJc=
 cloud.google.com/go/managedidentities v1.3.0/go.mod h1:UzlW3cBOiPrzucO5qWkNkh0w33KFtBJU281hacNvsdE=
 cloud.google.com/go/managedidentities v1.4.0/go.mod h1:NWSBYbEMgqmbZsLIyKvxrYbtqOsxY1ZrGM+9RgDqInM=
+cloud.google.com/go/maps v0.1.0/go.mod h1:BQM97WGyfw9FWEmQMpZ5T6cpovXXSd1cGmFma94eubI=
 cloud.google.com/go/mediatranslation v0.5.0/go.mod h1:jGPUhGTybqsPQn91pNXw0xVHfuJ3leR1wj37oU3y1f4=
 cloud.google.com/go/mediatranslation v0.6.0/go.mod h1:hHdBCTYNigsBxshbznuIMFNe5QXEowAuNmmC7h8pu5w=
 cloud.google.com/go/memcache v1.4.0/go.mod h1:rTOfiGZtJX1AaFUrOgsMHX5kAzaTQ8azHiuDoTPzNsE=
@@ -368,6 +370,7 @@ cloud.google.com/go/vision/v2 v2.4.0/go.mod h1:VtI579ll9RpVTrdKdkMzckdnwMyX2JILb
 cloud.google.com/go/vision/v2 v2.5.0/go.mod h1:MmaezXOOE+IWa+cS7OhRRLK2cNv1ZL98zhqFFZaaH2E=
 cloud.google.com/go/vmmigration v1.2.0/go.mod h1:IRf0o7myyWFSmVR1ItrBSFLFD/rJkfDCUTO4vLlJvsE=
 cloud.google.com/go/vmmigration v1.3.0/go.mod h1:oGJ6ZgGPQOFdjHuocGcLqX4lc98YQ7Ygq8YQwHh9A7g=
+cloud.google.com/go/vmwareengine v0.1.0/go.mod h1:RsdNEf/8UDvKllXhMz5J40XxDrNJNN4sagiox+OI208=
 cloud.google.com/go/vpcaccess v1.4.0/go.mod h1:aQHVbTWDYUR1EbTApSVvMq1EnT57ppDmQzZ3imqIk4w=
 cloud.google.com/go/vpcaccess v1.5.0/go.mod h1:drmg4HLk9NkZpGfCmZ3Tz0Bwnm2+DKqViEpeEpOq0m8=
 cloud.google.com/go/webrisk v1.4.0/go.mod h1:Hn8X6Zr+ziE2aNd8SliSDWpEnSS1u4R9+xXZmFiHmGE=
@@ -452,6 +455,8 @@ github.com/go-swiss/fonts v0.0.0-20210417170609-5d357d615b8f/go.mod h1:kDru5pqfn
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
@@ -541,7 +546,10 @@ github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMd
 github.com/googleapis/gax-go/v2 v2.7.0 h1:IcsPKeInNvYi7eqSaDjiZqDDKu5rsmunY0Y1YupQSSQ=
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -728,8 +736,9 @@ golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/net v0.0.0-20221014081412-f15817d10f9b h1:tvrvnPFcdzp294diPnrdZZZ8XUt2Tyj7svb7X52iDuU=
 golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.3.0 h1:VWL6FNY2bEEmsGVKabSlHu5Irp34xmMRoqb/9lF9lxk=
+golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -755,8 +764,9 @@ golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7Lm
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
-golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=
 golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/oauth2 v0.3.0 h1:6l90koy8/LaBLmLu8jpHeHexzMwEita0zFfYlggy2F8=
+golang.org/x/oauth2 v0.3.0/go.mod h1:rQrIauxkUhJ6CuwEXwymO2/eh4xz2ZWF1nBkcxS+tGk=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -837,10 +847,12 @@ golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1087,11 +1099,13 @@ google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a/go.mod h1:1vXfmgAz
 google.golang.org/genproto v0.0.0-20221024153911-1573dae28c9c/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
 google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
 google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c/go.mod h1:CGI5F/G+E5bKwmfYo09AXuVN4dD894kIKUFmVbP2/Fo=
+google.golang.org/genproto v0.0.0-20221114212237-e4508ebdbee1/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
-google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6 h1:AGXp12e/9rItf6/4QymU7WsAUwCf+ICW75cuR91nJIc=
 google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6/go.mod h1:1dOng4TWOomJrDGhpXjfCD35wQC6jnC7HpRmOFRqEV0=
+google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSgaFAGyInDXeWzUhvYH57G/5GKMn70=
+google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/invites.go
+++ b/invites.go
@@ -129,7 +129,7 @@ func (srv *groupsAPI) ListInvites(ctx context.Context, req *notesv1.ListInvitesR
 			return nil, err
 		}
 		member := group.FindMember(token.AccountID)
-		if !member.IsAdmin {
+		if member == nil || !member.IsAdmin {
 			return nil, status.Error(codes.PermissionDenied, "forbidden operation")
 		}
 	} else {

--- a/invites.go
+++ b/invites.go
@@ -140,14 +140,12 @@ func (srv *groupsAPI) ListInvites(ctx context.Context, req *notesv1.ListInvitesR
 
 	invites, err := srv.groups.ListInvites(ctx,
 		&models.ManyInvitesFilter{
-			SenderAccountID:    &req.SenderAccountId,
-			RecipientAccountID: &req.RecipientAccountId,
-			GroupID:            &req.GroupId,
+			SenderAccountID:    req.SenderAccountId,
+			RecipientAccountID: req.RecipientAccountId,
+			GroupID:            req.GroupId,
 		},
-		&models.ListOptions{
-			Limit:  int64(req.Limit),
-			Offset: int64(req.Offset),
-		})
+		listOptionsFromLimitOffset(req.Limit, req.Offset),
+	)
 
 	if err != nil {
 		return nil, statusFromModelError(err)

--- a/invites.go
+++ b/invites.go
@@ -130,7 +130,7 @@ func (srv *groupsAPI) ListInvites(ctx context.Context, req *notesv1.ListInvitesR
 				return nil, err
 			}
 			member := group.FindMember(token.AccountID)
-			if member == nil || !member.IsAdmin {
+			if member == nil {
 				return nil, status.Error(codes.PermissionDenied, "forbidden operation")
 			}
 		} else {

--- a/invites_test.go
+++ b/invites_test.go
@@ -19,7 +19,11 @@ func TestInvitesSuite(t *testing.T) {
 	dave := newTestAccount(t, tu)
 	kerchakGroup := newTestGroup(t, tu, kerchak, member)
 
-	// TODO: t.Run("stranger-cannot-send-invite", func(t *testing.T) {})
+	t.Run("stranger-cannot-send-invite", func(t *testing.T) {
+		res, err := tu.groups.SendInvite(stranger.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
 	var protoInviteSlot *v1.GroupInvite
 
@@ -39,11 +43,23 @@ func TestInvitesSuite(t *testing.T) {
 		protoInviteSlot = res.Invite
 	})
 
-	// TODO: t.Run("member-cannot-send-invite-to-self", func(t *testing.T) {})
+	t.Run("member-cannot-send-invite-to-self", func(t *testing.T) {
+		res, err := tu.groups.SendInvite(member.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: member.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
-	// TODO: t.Run("member-cannot-send-invite-to-member", func(t *testing.T) {})
+	t.Run("member-cannot-send-invite-to-member", func(t *testing.T) {
+		res, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: member.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
-	// TODO: t.Run("member-cannot-send-duplicate-invite", func(t *testing.T) {})
+	t.Run("member-cannot-send-duplicate-invite", func(t *testing.T) {
+		res, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
 	t.Run("stranger-cannot-get-invite", func(t *testing.T) {
 		res, err := tu.groups.GetInvite(stranger.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
@@ -75,9 +91,17 @@ func TestInvitesSuite(t *testing.T) {
 		require.Nil(t, res)
 	})
 
-	// TODO: t.Run("stranger-cannot-deny-invite", func(t *testing.T) {})
+	t.Run("stranger-cannot-deny-invite", func(t *testing.T) {
+		res, err := tu.groups.DenyInvite(stranger.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
-	// TODO: t.Run("member-cannot-deny-invite", func(t *testing.T) {})
+	t.Run("member-cannot-deny-invite", func(t *testing.T) {
+		res, err := tu.groups.DenyInvite(member.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
 	t.Run("recipient-can-deny-invite", func(t *testing.T) {
 		res, err := tu.groups.DenyInvite(dave.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
@@ -98,11 +122,23 @@ func TestInvitesSuite(t *testing.T) {
 
 	kerchakDaveInvite := kerchak.SendInvite(t, tu, dave, kerchakGroup)
 
-	// TODO: t.Run("stranger-cannot-accept-invite", func(t *testing.T) {})
+	t.Run("stranger-cannot-accept-invite", func(t *testing.T) {
+		res, err := tu.groups.AcceptInvite(stranger.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: kerchakDaveInvite.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
-	// TODO: t.Run("sender-cannot-accept-invite", func(t *testing.T) {})
+	t.Run("sender-cannot-accept-invite", func(t *testing.T) {
+		res, err := tu.groups.AcceptInvite(kerchak.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: kerchakDaveInvite.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
-	// TODO: t.Run("member-cannot-accept-invite", func(t *testing.T) {}})
+	t.Run("member-cannot-accept-invite", func(t *testing.T) {
+		res, err := tu.groups.AcceptInvite(member.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: kerchakDaveInvite.ID})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
 	t.Run("recipient-can-accept-invite", func(t *testing.T) {
 		res, err := tu.groups.AcceptInvite(dave.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: kerchakDaveInvite.ID})
@@ -135,24 +171,38 @@ func TestInvitesSuite(t *testing.T) {
 		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, jhon.ID))
 	})
 
-	// TODO: t.Run("list-invites-is-correctly-paginated", func(t *testing.T) {})
-
-	// TODO: t.Run("user-can-list-invites-they-sent", func(t *testing.T) {})
-
+	// Presets for ListInvites unit-tests
+	// Creates 3 new users, one group owned by dave
 	randomUserOne := newTestAccount(t, tu)
 	randomUserTwo := newTestAccount(t, tu)
 	randomUserThree := newTestAccount(t, tu)
+	daveGroup := newTestGroup(t, tu, dave)
+	// Send to the 3 new users an invite to kerchakGroup (by dave)
 	testAccountSlots := [3]*testAccount{randomUserOne, randomUserTwo, randomUserThree}
 	for _, account := range testAccountSlots {
 		dave.SendInvite(t, tu, account, kerchakGroup)
 	}
+	// Sends randomUserOne an invite for dave's group (by dave)
+	dave.SendInvite(t, tu, randomUserOne, daveGroup)
+
+	t.Run("user-can-list-invites-they-sent", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		// Check all invites are returned. The 3 sent on kerchak group, and the one on Dave's group
+		require.Equal(t, len(res.Invites), 4)
+		for _, invite := range res.Invites {
+			require.Equal(t, invite.SenderAccountId, dave.ID)
+		}
+	})
 
 	t.Run("member-can-list-invites-they-sent-in-group", func(t *testing.T) {
 		res, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
-		// Check all invites are returned.
+		// Check all invites are returned. The 3 sent on kerchak groups by dave
 		require.Equal(t, len(res.Invites), 3)
 		for _, invite := range res.Invites {
 			require.Equal(t, invite.SenderAccountId, dave.ID)
@@ -160,31 +210,101 @@ func TestInvitesSuite(t *testing.T) {
 		}
 	})
 
+	t.Run("list-invites-is-correctly-paginated", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{
+			SenderAccountId: dave.ID,
+			GroupId:         kerchakGroup.ID,
+			Limit:           1,
+			Offset:          1,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		// Check that the invite of randomUserTwo is returned.
+		require.Equal(t, len(res.Invites), 1)
+		invite := res.Invites[0]
+		require.Equal(t, invite.SenderAccountId, dave.ID)
+		require.Equal(t, invite.RecipientAccountId, randomUserTwo.ID)
+		require.Equal(t, kerchakGroup.ID, invite.GroupId)
+	})
+
 	t.Run("user-can-list-invites-destined-to-them", func(t *testing.T) {
 		res, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
 		require.NoError(t, err)
+
+		// Check that there is the one invite from dave's group and kerchak's group
+		require.Equal(t, len(res.Invites), 2)
+		for _, invite := range res.Invites {
+			require.Equal(t, invite.SenderAccountId, dave.ID)
+			require.Equal(t, invite.RecipientAccountId, randomUserOne.ID)
+		}
+	})
+
+	var randomUserOneKerchakInvite *testInvite
+
+	t.Run("user-can-list-invites-destined-to-them-in-group", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID, GroupId: kerchakGroup.ID})
+		require.NoError(t, err)
+
+		// Check that there is only the one sent by dave on kerchak's group
 		require.Equal(t, len(res.Invites), 1)
 		require.Equal(t, res.Invites[0].SenderAccountId, dave.ID)
 		require.Equal(t, res.Invites[0].RecipientAccountId, randomUserOne.ID)
 		require.Equal(t, res.Invites[0].GroupId, kerchakGroup.ID)
+
+		// Store this invite for later
+		randomUserOneKerchakInvite = &testInvite{
+			recipient: randomUserOne,
+			sender:    dave,
+			group:     kerchakGroup,
+			ID:        res.Invites[0].Id,
+		}
 	})
 
-	// TODO: t.Run("user-can-list-invites-destined-to-them-in-group", func(t *testing.T) {})
-
-	t.Run("invitee-cannot-list-invites-destined-to-someone-else", func(t *testing.T) {
+	t.Run("invite-cannot-list-invites-destined-to-someone-else", func(t *testing.T) {
 		res, err := tu.groups.ListInvites(randomUserTwo.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
 		requireErrorHasGRPCCode(t, codes.PermissionDenied, err)
 		require.Nil(t, res)
 	})
 
-	// TODO: t.Run("user-can-list-invites-in-group", func(t *testing.T) {})
+	// Accept the previously stored invite
+	randomUserOne.AcceptInvite(t, tu, randomUserOneKerchakInvite)
 
-	// TODO: t.Run("stranger-cannot-revoke-invite", func(t *testing.T) {})
+	t.Run("user-can-list-invites-in-group", func(t *testing.T) {
+		// Now RandomUserOne can ListInvites
+		res, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{
+			GroupId: kerchakGroup.ID,
+		})
 
-	// TODO: t.Run("recipient-cannot-revoke-invite", func(t *testing.T) {})
+		require.NoError(t, err)
+		// There is 2 invites left in kerchak's group, for randomUserTwo and randomUserThree
+		require.Equal(t, len(res.Invites), 2)
+		for _, invite := range res.Invites {
+			require.Equal(t, invite.GroupId, kerchakGroup.ID)
+			require.NotEqual(t, invite.RecipientAccountId, randomUserOne.ID)
+		}
+	})
 
 	maxime := newTestAccount(t, tu)
 	kerchakMaximeInvite := dave.SendInvite(t, tu, maxime, kerchakGroup)
+
+	t.Run("stranger-cannot-revoke-invite", func(t *testing.T) {
+		res, err := tu.groups.RevokeInvite(stranger.Context, &v1.RevokeInviteRequest{
+			GroupId:  kerchakMaximeInvite.group.ID,
+			InviteId: kerchakMaximeInvite.ID,
+		})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("recipient-cannot-revoke-invite", func(t *testing.T) {
+		res, err := tu.groups.RevokeInvite(maxime.Context, &v1.RevokeInviteRequest{
+			GroupId:  kerchakMaximeInvite.group.ID,
+			InviteId: kerchakMaximeInvite.ID,
+		})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
+		require.Nil(t, res)
+	})
 
 	t.Run("sender-can-revoke-invite", func(t *testing.T) {
 		res, err := tu.groups.RevokeInvite(dave.Context, &v1.RevokeInviteRequest{
@@ -198,19 +318,19 @@ func TestInvitesSuite(t *testing.T) {
 		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
 		require.NoError(t, err)
 		require.Nil(t, group.FindInvite(kerchakMaximeInvite.ID))
-		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, randomUserOne.ID))
-		require.Nil(t, group.FindMember(randomUserOne.ID))
+		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, maxime.ID))
+		require.Nil(t, group.FindMember(maxime.ID))
 	})
 
-	// diego := newTestAccount(t, tu)
-	// kerchakDiegoInvite := dave.SendInvite(t, tu, diego, kerchakGroup)
+	diego := newTestAccount(t, tu)
+	kerchakDiegoInvite := dave.SendInvite(t, tu, diego, kerchakGroup)
 
-	// t.Run("admin-can-revoke-invite", func(t *testing.T) {
-	// 	res, err := tu.groups.RevokeInvite(kerchak.Context, &v1.RevokeInviteRequest{
-	// 		GroupId:  kerchakGroup.ID,
-	// 		InviteId: kerchakDiegoInvite.ID,
-	// 	})
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, res)
-	// })
+	t.Run("admin-can-revoke-invite", func(t *testing.T) {
+		res, err := tu.groups.RevokeInvite(kerchak.Context, &v1.RevokeInviteRequest{
+			GroupId:  kerchakGroup.ID,
+			InviteId: kerchakDiegoInvite.ID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
 }

--- a/invites_test.go
+++ b/invites_test.go
@@ -1,1 +1,84 @@
 package main
+
+import (
+	v1 "notes-service/protorepo/noted/notes/v1"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvitesSuite(t *testing.T) {
+	tu := newTestUtilsOrDie(t)
+	kerchak := newTestAccount(t, tu)
+	randomDude := newTestAccount(t, tu)
+	dave := newTestAccount(t, tu)
+	kerchakGroup := newTestGroup(t, tu, kerchak)
+
+	var inviteSlot *v1.GroupInvite
+
+	t.Run("send-and-get-invite", func(t *testing.T) {
+		sendInviteRes, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
+		require.NoError(t, err)
+		require.Equal(t, sendInviteRes.Invite.GroupId, kerchakGroup.ID)
+		require.Equal(t, sendInviteRes.Invite.SenderAccountId, kerchak.ID)
+		require.Equal(t, sendInviteRes.Invite.RecipientAccountId, dave.ID)
+
+		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: sendInviteRes.Invite.Id})
+		require.NoError(t, err)
+		require.Equal(t, getInviteRes.Invite.GroupId, kerchakGroup.ID)
+		require.Equal(t, getInviteRes.Invite.SenderAccountId, kerchak.ID)
+		require.Equal(t, getInviteRes.Invite.RecipientAccountId, dave.ID)
+
+		inviteSlot = getInviteRes.Invite
+	})
+
+	t.Run("get-invite-rights-check", func(t *testing.T) {
+		// Random Dude should not have the rights
+		res, err := tu.groups.GetInvite(randomDude.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		// Kerchak should have the right, dave already has been tested
+		res, err = tu.groups.GetInvite(kerchak.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("deny-invite-and-rights", func(t *testing.T) {
+		res, err := tu.groups.DenyInvite(kerchak.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.Error(t, err)
+		require.Nil(t, res)
+		res, err = tu.groups.DenyInvite(randomDude.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		res, err = tu.groups.DenyInvite(dave.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		require.Error(t, err)
+		require.Nil(t, getInviteRes)
+
+		getGroupRes, err := tu.groups.GetGroup(dave.Context, &v1.GetGroupRequest{GroupId: kerchak.ID})
+		require.Error(t, err)
+		require.Nil(t, getGroupRes)
+	})
+
+	t.Run("accept-invite", func(t *testing.T) {
+		sendInviteRes, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
+		require.NoError(t, err)
+		require.NotNil(t, sendInviteRes)
+
+		acceptRes, err := tu.groups.AcceptInvite(dave.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: sendInviteRes.Invite.Id})
+		require.NoError(t, err)
+		require.NotNil(t, acceptRes)
+
+		getGroupRes, err := tu.groups.GetGroup(dave.Context, &v1.GetGroupRequest{GroupId: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.NotNil(t, getGroupRes)
+		require.Equal(t, len(getGroupRes.Group.Members), 2)
+		require.Equal(t, getGroupRes.Group.Members[1].AccountId, dave.ID) // idk man not gonna do loops and shit
+	})
+
+}

--- a/invites_test.go
+++ b/invites_test.go
@@ -14,9 +14,12 @@ func TestInvitesSuite(t *testing.T) {
 	dave := newTestAccount(t, tu)
 	kerchakGroup := newTestGroup(t, tu, kerchak)
 
-	var inviteSlot *v1.GroupInvite
+	var protoInviteSlot *v1.GroupInvite
 
-	t.Run("send-and-get-invite", func(t *testing.T) {
+	var testAccountSlots [3]*testAccount
+	var testInviteSlots [3]*testInvite
+
+	t.Run("send-invite", func(t *testing.T) {
 		sendInviteRes, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
 		require.NoError(t, err)
 		require.Equal(t, sendInviteRes.Invite.GroupId, kerchakGroup.ID)
@@ -29,34 +32,35 @@ func TestInvitesSuite(t *testing.T) {
 		require.Equal(t, getInviteRes.Invite.SenderAccountId, kerchak.ID)
 		require.Equal(t, getInviteRes.Invite.RecipientAccountId, dave.ID)
 
-		inviteSlot = getInviteRes.Invite
+		protoInviteSlot = getInviteRes.Invite
 	})
 
-	t.Run("get-invite-rights-check", func(t *testing.T) {
+	t.Run("get-invite-forbidden", func(t *testing.T) {
 		// Random Dude should not have the rights
-		res, err := tu.groups.GetInvite(randomDude.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		res, err := tu.groups.GetInvite(randomDude.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.Error(t, err)
 		require.Nil(t, res)
+	})
 
+	t.Run("get-invite", func(t *testing.T) {
 		// Kerchak should have the right, dave already has been tested
-		res, err = tu.groups.GetInvite(kerchak.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		res, err := tu.groups.GetInvite(kerchak.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 	})
 
-	t.Run("deny-invite-and-rights", func(t *testing.T) {
-		res, err := tu.groups.DenyInvite(kerchak.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+	t.Run("deny-invite-not-recipient", func(t *testing.T) {
+		res, err := tu.groups.DenyInvite(kerchak.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.Error(t, err)
 		require.Nil(t, res)
-		res, err = tu.groups.DenyInvite(randomDude.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
-		require.Error(t, err)
-		require.Nil(t, res)
+	})
 
-		res, err = tu.groups.DenyInvite(dave.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+	t.Run("deny-invite", func(t *testing.T) {
+		res, err := tu.groups.DenyInvite(dave.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
-		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: inviteSlot.Id})
+		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.Error(t, err)
 		require.Nil(t, getInviteRes)
 
@@ -81,20 +85,16 @@ func TestInvitesSuite(t *testing.T) {
 		require.Equal(t, getGroupRes.Group.Members[1].AccountId, dave.ID) // idk man not gonna do loops and shit
 	})
 
-	t.Run("list-invite-extensive", func(t *testing.T) {
+	t.Run("list-invite-from-sender", func(t *testing.T) {
 		randomUserOne := newTestAccount(t, tu)
 		randomUserTwo := newTestAccount(t, tu)
 		randomUserThree := newTestAccount(t, tu)
 
-		accountList := [3]*testAccount{randomUserOne, randomUserTwo, randomUserThree}
-		var inviteList [3]*v1.GroupInvite
+		testAccountSlots = [3]*testAccount{randomUserOne, randomUserTwo, randomUserThree}
 
 		// Send invites two the three new accounts
-		for idx, account := range accountList {
-			sendInviteRes, err := tu.groups.SendInvite(dave.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: account.ID})
-			require.NoError(t, err)
-			require.NotNil(t, sendInviteRes)
-			inviteList[idx] = sendInviteRes.Invite
+		for idx, account := range testAccountSlots {
+			testInviteSlots[idx] = dave.SendInvite(t, tu, account, kerchakGroup)
 		}
 
 		// List from dave's context
@@ -107,31 +107,39 @@ func TestInvitesSuite(t *testing.T) {
 		for _, invite := range invitesList.Invites {
 			require.Equal(t, invite.SenderAccountId, dave.ID)
 		}
+	})
 
+	t.Run("list-invite-from-recipient", func(t *testing.T) {
+		randomUserOne := testAccountSlots[0]
 		// Test on an invited account, basic check on the returned list (len and ids)
-		invitesList, err = tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
+		invitesList, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
 		require.NoError(t, err)
 		require.Equal(t, len(invitesList.Invites), 1)
 		require.Equal(t, invitesList.Invites[0].SenderAccountId, dave.ID)
 		require.Equal(t, invitesList.Invites[0].RecipientAccountId, randomUserOne.ID)
 		require.Equal(t, invitesList.Invites[0].GroupId, kerchakGroup.ID)
 
+	})
+
+	t.Run("list-invite-forbidden", func(t *testing.T) {
+		randomUserOne := testAccountSlots[0]
+		randomUserTwo := testAccountSlots[1]
+
 		// Test that you can't fetch another person invites
-		invitesList, err = tu.groups.ListInvites(randomUserTwo.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
+		invitesList, err := tu.groups.ListInvites(randomUserTwo.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
 		require.Error(t, err)
 		require.Nil(t, invitesList)
+	})
 
+	t.Run("list-invite-after-everybody-accepted", func(t *testing.T) {
 		// Accept every invite and show that the list of dave's invites is now 0
-		for idx, invite := range inviteList {
-			curAccount := accountList[idx]
-
-			acceptInviteRes, err := tu.groups.AcceptInvite(curAccount.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: invite.Id})
-			require.NoError(t, err)
-			require.NotNil(t, acceptInviteRes)
+		for idx, invite := range testInviteSlots {
+			account := testAccountSlots[idx]
+			account.AcceptInvite(t, tu, invite)
 		}
 
-		// List from dave's context
-		invitesList, err = tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
+		// List from dave's sender context
+		invitesList, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
 		require.NoError(t, err)
 		require.NotNil(t, invitesList)
 		require.Equal(t, len(invitesList.Invites), 0)
@@ -139,20 +147,17 @@ func TestInvitesSuite(t *testing.T) {
 
 	t.Run("revoke-invite", func(t *testing.T) {
 		randomUserOne := newTestAccount(t, tu)
-		sendInviteRes, err := tu.groups.SendInvite(dave.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: randomUserOne.ID})
-		require.NoError(t, err)
-		require.NotNil(t, sendInviteRes)
 
-		invite := sendInviteRes.Invite
+		invite := dave.SendInvite(t, tu, randomUserOne, kerchakGroup)
 
 		revokeRes, err := tu.groups.RevokeInvite(dave.Context, &v1.RevokeInviteRequest{
-			GroupId:  kerchakGroup.ID,
-			InviteId: invite.Id,
+			GroupId:  invite.group.ID,
+			InviteId: invite.ID,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, revokeRes)
 
-		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: invite.Id})
+		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: invite.ID})
 		require.Error(t, err)
 		require.Nil(t, getInviteRes)
 	})

--- a/invites_test.go
+++ b/invites_test.go
@@ -1,165 +1,216 @@
 package main
 
 import (
+	"context"
+	"notes-service/models"
 	v1 "notes-service/protorepo/noted/notes/v1"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func TestInvitesSuite(t *testing.T) {
 	tu := newTestUtilsOrDie(t)
+	stranger := newTestAccount(t, tu)
+	member := newTestAccount(t, tu)
 	kerchak := newTestAccount(t, tu)
-	randomDude := newTestAccount(t, tu)
+	jhon := newTestAccount(t, tu)
 	dave := newTestAccount(t, tu)
-	kerchakGroup := newTestGroup(t, tu, kerchak)
+	kerchakGroup := newTestGroup(t, tu, kerchak, member)
+
+	// TODO: t.Run("stranger-cannot-send-invite", func(t *testing.T) {})
 
 	var protoInviteSlot *v1.GroupInvite
 
-	var testAccountSlots [3]*testAccount
-	var testInviteSlots [3]*testInvite
-
-	t.Run("send-invite", func(t *testing.T) {
-		sendInviteRes, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
+	t.Run("member-can-send-invite", func(t *testing.T) {
+		res, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
 		require.NoError(t, err)
-		require.Equal(t, sendInviteRes.Invite.GroupId, kerchakGroup.ID)
-		require.Equal(t, sendInviteRes.Invite.SenderAccountId, kerchak.ID)
-		require.Equal(t, sendInviteRes.Invite.RecipientAccountId, dave.ID)
+		require.Equal(t, res.Invite.GroupId, kerchakGroup.ID)
+		require.Equal(t, res.Invite.SenderAccountId, kerchak.ID)
+		require.Equal(t, res.Invite.RecipientAccountId, dave.ID)
 
-		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: sendInviteRes.Invite.Id})
+		// Check invite is stored in the database.
+		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
 		require.NoError(t, err)
-		require.Equal(t, getInviteRes.Invite.GroupId, kerchakGroup.ID)
-		require.Equal(t, getInviteRes.Invite.SenderAccountId, kerchak.ID)
-		require.Equal(t, getInviteRes.Invite.RecipientAccountId, dave.ID)
+		require.NotNil(t, group.FindInvite(res.Invite.Id))
+		require.NotNil(t, group.FindInviteByAccountTuple(dave.ID, kerchak.ID))
 
-		protoInviteSlot = getInviteRes.Invite
+		protoInviteSlot = res.Invite
 	})
 
-	t.Run("get-invite-forbidden", func(t *testing.T) {
-		// Random Dude should not have the rights
-		res, err := tu.groups.GetInvite(randomDude.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
-		require.Error(t, err)
+	// TODO: t.Run("member-cannot-send-invite-to-self", func(t *testing.T) {})
+
+	// TODO: t.Run("member-cannot-send-invite-to-member", func(t *testing.T) {})
+
+	// TODO: t.Run("member-cannot-send-duplicate-invite", func(t *testing.T) {})
+
+	t.Run("stranger-cannot-get-invite", func(t *testing.T) {
+		res, err := tu.groups.GetInvite(stranger.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
 		require.Nil(t, res)
 	})
 
-	t.Run("get-invite", func(t *testing.T) {
-		// Kerchak should have the right, dave already has been tested
+	t.Run("recipient-can-get-invite", func(t *testing.T) {
+		res, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("sender-can-get-invite", func(t *testing.T) {
 		res, err := tu.groups.GetInvite(kerchak.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 	})
 
-	t.Run("deny-invite-not-recipient", func(t *testing.T) {
+	t.Run("member-can-get-invite", func(t *testing.T) {
+		res, err := tu.groups.GetInvite(member.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("sender-cannot-deny-invite", func(t *testing.T) {
 		res, err := tu.groups.DenyInvite(kerchak.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
-		require.Error(t, err)
+		requireErrorHasGRPCCode(t, codes.NotFound, err)
 		require.Nil(t, res)
 	})
 
-	t.Run("deny-invite", func(t *testing.T) {
+	// TODO: t.Run("stranger-cannot-deny-invite", func(t *testing.T) {})
+
+	// TODO: t.Run("member-cannot-deny-invite", func(t *testing.T) {})
+
+	t.Run("recipient-can-deny-invite", func(t *testing.T) {
 		res, err := tu.groups.DenyInvite(dave.Context, &v1.DenyInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
-		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: protoInviteSlot.Id})
-		require.Error(t, err)
-		require.Nil(t, getInviteRes)
+		// Check invite is deleted from the database.
+		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.Nil(t, group.FindInvite(protoInviteSlot.Id))
+		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, kerchak.ID))
 
-		getGroupRes, err := tu.groups.GetGroup(dave.Context, &v1.GetGroupRequest{GroupId: kerchak.ID})
-		require.Error(t, err)
+		// Check recipient has no access to group.
+		getGroupRes, err := tu.groups.GetGroup(dave.Context, &v1.GetGroupRequest{GroupId: kerchakGroup.ID})
+		requireErrorHasGRPCCode(t, codes.PermissionDenied, err)
 		require.Nil(t, getGroupRes)
 	})
 
-	t.Run("accept-invite", func(t *testing.T) {
-		sendInviteRes, err := tu.groups.SendInvite(kerchak.Context, &v1.SendInviteRequest{GroupId: kerchakGroup.ID, RecipientAccountId: dave.ID})
-		require.NoError(t, err)
-		require.NotNil(t, sendInviteRes)
+	kerchakDaveInvite := kerchak.SendInvite(t, tu, dave, kerchakGroup)
 
-		acceptRes, err := tu.groups.AcceptInvite(dave.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: sendInviteRes.Invite.Id})
-		require.NoError(t, err)
-		require.NotNil(t, acceptRes)
+	// TODO: t.Run("stranger-cannot-accept-invite", func(t *testing.T) {})
 
-		getGroupRes, err := tu.groups.GetGroup(dave.Context, &v1.GetGroupRequest{GroupId: kerchakGroup.ID})
+	// TODO: t.Run("sender-cannot-accept-invite", func(t *testing.T) {})
+
+	// TODO: t.Run("member-cannot-accept-invite", func(t *testing.T) {}})
+
+	t.Run("recipient-can-accept-invite", func(t *testing.T) {
+		res, err := tu.groups.AcceptInvite(dave.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: kerchakDaveInvite.ID})
 		require.NoError(t, err)
-		require.NotNil(t, getGroupRes)
-		require.Equal(t, len(getGroupRes.Group.Members), 2)
-		require.Equal(t, getGroupRes.Group.Members[1].AccountId, dave.ID) // idk man not gonna do loops and shit
+		require.NotNil(t, res)
+
+		// Check invite is deleted from the database and recipient has been added to group.
+		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.Nil(t, group.FindInvite(kerchakDaveInvite.ID))
+		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, kerchak.ID))
+		require.NotNil(t, group.FindMember(dave.ID))
+		require.Len(t, *group.Members, 3)
 	})
 
-	t.Run("list-invite-from-sender", func(t *testing.T) {
-		randomUserOne := newTestAccount(t, tu)
-		randomUserTwo := newTestAccount(t, tu)
-		randomUserThree := newTestAccount(t, tu)
+	kerchakJhonInvite := kerchak.SendInvite(t, tu, jhon, kerchakGroup)
+	daveJhonInvite := dave.SendInvite(t, tu, jhon, kerchakGroup)
 
-		testAccountSlots = [3]*testAccount{randomUserOne, randomUserTwo, randomUserThree}
-
-		// Send invites two the three new accounts
-		for idx, account := range testAccountSlots {
-			testInviteSlots[idx] = dave.SendInvite(t, tu, account, kerchakGroup)
-		}
-
-		// List from dave's context
-		invitesList, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
+	t.Run("accept-invite-deletes-all-invites-destined-to-recipient", func(t *testing.T) {
+		res, err := tu.groups.AcceptInvite(jhon.Context, &v1.AcceptInviteRequest{GroupId: kerchakGroup.ID, InviteId: daveJhonInvite.ID})
 		require.NoError(t, err)
-		require.NotNil(t, invitesList)
+		require.NotNil(t, res)
 
-		// Len and senderID check
-		require.Equal(t, len(invitesList.Invites), 3)
-		for _, invite := range invitesList.Invites {
+		// Check all invites are deleted from the database.
+		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.Nil(t, group.FindInvite(kerchakJhonInvite.ID))
+		require.Nil(t, group.FindInviteByAccountTuple(kerchak.ID, jhon.ID))
+		require.Nil(t, group.FindInvite(daveJhonInvite.ID))
+		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, jhon.ID))
+	})
+
+	// TODO: t.Run("list-invites-is-correctly-paginated", func(t *testing.T) {})
+
+	// TODO: t.Run("user-can-list-invites-they-sent", func(t *testing.T) {})
+
+	randomUserOne := newTestAccount(t, tu)
+	randomUserTwo := newTestAccount(t, tu)
+	randomUserThree := newTestAccount(t, tu)
+	testAccountSlots := [3]*testAccount{randomUserOne, randomUserTwo, randomUserThree}
+	for _, account := range testAccountSlots {
+		dave.SendInvite(t, tu, account, kerchakGroup)
+	}
+
+	t.Run("member-can-list-invites-they-sent-in-group", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		// Check all invites are returned.
+		require.Equal(t, len(res.Invites), 3)
+		for _, invite := range res.Invites {
 			require.Equal(t, invite.SenderAccountId, dave.ID)
+			require.Equal(t, kerchakGroup.ID, invite.GroupId)
 		}
 	})
 
-	t.Run("list-invite-from-recipient", func(t *testing.T) {
-		randomUserOne := testAccountSlots[0]
-		// Test on an invited account, basic check on the returned list (len and ids)
-		invitesList, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
+	t.Run("user-can-list-invites-destined-to-them", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(randomUserOne.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
 		require.NoError(t, err)
-		require.Equal(t, len(invitesList.Invites), 1)
-		require.Equal(t, invitesList.Invites[0].SenderAccountId, dave.ID)
-		require.Equal(t, invitesList.Invites[0].RecipientAccountId, randomUserOne.ID)
-		require.Equal(t, invitesList.Invites[0].GroupId, kerchakGroup.ID)
-
+		require.Equal(t, len(res.Invites), 1)
+		require.Equal(t, res.Invites[0].SenderAccountId, dave.ID)
+		require.Equal(t, res.Invites[0].RecipientAccountId, randomUserOne.ID)
+		require.Equal(t, res.Invites[0].GroupId, kerchakGroup.ID)
 	})
 
-	t.Run("list-invite-forbidden", func(t *testing.T) {
-		randomUserOne := testAccountSlots[0]
-		randomUserTwo := testAccountSlots[1]
+	// TODO: t.Run("user-can-list-invites-destined-to-them-in-group", func(t *testing.T) {})
 
-		// Test that you can't fetch another person invites
-		invitesList, err := tu.groups.ListInvites(randomUserTwo.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
-		require.Error(t, err)
-		require.Nil(t, invitesList)
+	t.Run("invitee-cannot-list-invites-destined-to-someone-else", func(t *testing.T) {
+		res, err := tu.groups.ListInvites(randomUserTwo.Context, &v1.ListInvitesRequest{RecipientAccountId: randomUserOne.ID})
+		requireErrorHasGRPCCode(t, codes.PermissionDenied, err)
+		require.Nil(t, res)
 	})
 
-	t.Run("list-invite-after-everybody-accepted", func(t *testing.T) {
-		// Accept every invite and show that the list of dave's invites is now 0
-		for idx, invite := range testInviteSlots {
-			account := testAccountSlots[idx]
-			account.AcceptInvite(t, tu, invite)
-		}
+	// TODO: t.Run("user-can-list-invites-in-group", func(t *testing.T) {})
 
-		// List from dave's sender context
-		invitesList, err := tu.groups.ListInvites(dave.Context, &v1.ListInvitesRequest{SenderAccountId: dave.ID, GroupId: kerchakGroup.ID})
-		require.NoError(t, err)
-		require.NotNil(t, invitesList)
-		require.Equal(t, len(invitesList.Invites), 0)
-	})
+	// TODO: t.Run("stranger-cannot-revoke-invite", func(t *testing.T) {})
 
-	t.Run("revoke-invite", func(t *testing.T) {
-		randomUserOne := newTestAccount(t, tu)
+	// TODO: t.Run("recipient-cannot-revoke-invite", func(t *testing.T) {})
 
-		invite := dave.SendInvite(t, tu, randomUserOne, kerchakGroup)
+	maxime := newTestAccount(t, tu)
+	kerchakMaximeInvite := dave.SendInvite(t, tu, maxime, kerchakGroup)
 
-		revokeRes, err := tu.groups.RevokeInvite(dave.Context, &v1.RevokeInviteRequest{
-			GroupId:  invite.group.ID,
-			InviteId: invite.ID,
+	t.Run("sender-can-revoke-invite", func(t *testing.T) {
+		res, err := tu.groups.RevokeInvite(dave.Context, &v1.RevokeInviteRequest{
+			GroupId:  kerchakMaximeInvite.group.ID,
+			InviteId: kerchakMaximeInvite.ID,
 		})
 		require.NoError(t, err)
-		require.NotNil(t, revokeRes)
+		require.NotNil(t, res)
 
-		getInviteRes, err := tu.groups.GetInvite(dave.Context, &v1.GetInviteRequest{GroupId: kerchakGroup.ID, InviteId: invite.ID})
-		require.Error(t, err)
-		require.Nil(t, getInviteRes)
+		// Check invite is deleted from the database and recipient has no access to group.
+		group, err := tu.groupsRepository.GetGroupInternal(context.Background(), &models.OneGroupFilter{GroupID: kerchakGroup.ID})
+		require.NoError(t, err)
+		require.Nil(t, group.FindInvite(kerchakMaximeInvite.ID))
+		require.Nil(t, group.FindInviteByAccountTuple(dave.ID, randomUserOne.ID))
+		require.Nil(t, group.FindMember(randomUserOne.ID))
 	})
 
+	// diego := newTestAccount(t, tu)
+	// kerchakDiegoInvite := dave.SendInvite(t, tu, diego, kerchakGroup)
+
+	// t.Run("admin-can-revoke-invite", func(t *testing.T) {
+	// 	res, err := tu.groups.RevokeInvite(kerchak.Context, &v1.RevokeInviteRequest{
+	// 		GroupId:  kerchakGroup.ID,
+	// 		InviteId: kerchakDiegoInvite.ID,
+	// 	})
+	// 	require.NoError(t, err)
+	// 	require.NotNil(t, res)
+	// })
 }

--- a/models/groups.go
+++ b/models/groups.go
@@ -225,8 +225,8 @@ type UpdateGroupConversationMessagePayload struct {
 }
 
 type ListInvitesResult struct {
-	GroupInvite
-	GroupID string
+	GroupInvite `json:"inline" bson:"inline"`
+	GroupID     string `json:"groupId" bson:"groupId"`
 }
 
 // GroupsRepository encapsulates the persistence layer that stores groups.
@@ -247,7 +247,7 @@ type GroupsRepository interface {
 	AcceptInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupMember, error)
 	DenyInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 	GetInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupInvite, error)
-	ListInvites(ctx context.Context, filter *ManyInvitesFilter, lo *ListOptions) ([]*GroupInvite, error)
+	ListInvites(ctx context.Context, filter *ManyInvitesFilter, lo *ListOptions) ([]*ListInvitesResult, error)
 	RevokeGroupInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 
 	// Conversations

--- a/models/groups.go
+++ b/models/groups.go
@@ -246,6 +246,7 @@ type GroupsRepository interface {
 	SendInvite(ctx context.Context, filter *OneGroupFilter, payload *SendInvitePayload, accountID string) (*GroupInvite, error)
 	AcceptInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupMember, error)
 	DenyInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
+	GetInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupInvite, error)
 	ListInvites(ctx context.Context, filter *ManyInvitesFilter, accountID string) ([]*ListInvitesResult, error)
 	RevokeGroupInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 

--- a/models/groups.go
+++ b/models/groups.go
@@ -247,7 +247,7 @@ type GroupsRepository interface {
 	AcceptInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupMember, error)
 	DenyInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 	GetInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupInvite, error)
-	ListInvites(ctx context.Context, filter *ManyInvitesFilter, accountID string) ([]*ListInvitesResult, error)
+	ListInvites(ctx context.Context, filter *ManyInvitesFilter, lo *ListOptions) ([]*ListInvitesResult, error)
 	RevokeGroupInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 
 	// Conversations

--- a/models/groups.go
+++ b/models/groups.go
@@ -166,11 +166,11 @@ type ManyGroupsFilter struct {
 
 type ManyInvitesFilter struct {
 	// (Optional) List all invites sent by this user.
-	SenderAccountID *string
+	SenderAccountID string
 	// (Optional) List all invites destined to this user.
-	RecipientAccountID *string
+	RecipientAccountID string
 	// (Optional) List all invites in this group.
-	GroupID *string
+	GroupID string
 }
 
 type CreateGroupPayload struct {

--- a/models/groups.go
+++ b/models/groups.go
@@ -247,7 +247,7 @@ type GroupsRepository interface {
 	AcceptInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupMember, error)
 	DenyInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 	GetInvite(ctx context.Context, filter *OneInviteFilter, accountID string) (*GroupInvite, error)
-	ListInvites(ctx context.Context, filter *ManyInvitesFilter, lo *ListOptions) ([]*ListInvitesResult, error)
+	ListInvites(ctx context.Context, filter *ManyInvitesFilter, lo *ListOptions) ([]*GroupInvite, error)
 	RevokeGroupInvite(ctx context.Context, filter *OneInviteFilter, accountID string) error
 
 	// Conversations

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -268,9 +268,9 @@ func (repo *groupsRepository) GetInvite(ctx context.Context, filter *models.OneI
 		{Key: "invites", Value: bson.D{
 			{Key: "$elemMatch", Value: bson.D{
 				{Key: "id", Value: filter.InviteID},
-				{Key: "$or", Value: bson.D{
-					{Key: "recipientAccountId", Value: accountID},
-					{Key: "senderAccountId", Value: accountID}, // idk better be sure u know
+				{Key: "$or", Value: bson.A{
+					bson.D{{Key: "recipientAccountId", Value: accountID}},
+					bson.D{{Key: "senderAccountId", Value: accountID}}, // idk better be sure u know
 				}},
 			}},
 		}},

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -288,8 +288,8 @@ func (repo *groupsRepository) GetInvite(ctx context.Context, filter *models.OneI
 	return &invites[0], nil
 }
 
-func (repo *groupsRepository) ListInvites(ctx context.Context, filter *models.ManyInvitesFilter, lo *models.ListOptions) ([]*models.ListInvitesResult, error) {
-	invites := make([]*models.ListInvitesResult, 0)
+func (repo *groupsRepository) ListInvites(ctx context.Context, filter *models.ManyInvitesFilter, lo *models.ListOptions) ([]*models.GroupInvite, error) {
+	invites := make([]*models.GroupInvite, 0)
 
 	mongoDocumentMatch := bson.D{}
 

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -277,12 +277,7 @@ func (repo *groupsRepository) GetInvite(ctx context.Context, filter *models.OneI
 				}},
 			},
 			bson.D{
-				{Key: "members", Value: bson.D{
-					{Key: "$elemMatch", Value: bson.D{
-						{Key: "accountId", Value: accountID},
-						{Key: "isAdmin", Value: true},
-					}},
-				}},
+				{Key: "members.accountId", Value: accountID},
 			},
 		}},
 	}

--- a/validators/invites.go
+++ b/validators/invites.go
@@ -19,3 +19,28 @@ func ValidateAcceptInviteRequest(req *notesv1.AcceptInviteRequest) error {
 		validation.Field(&req.InviteId, validation.Required),
 	)
 }
+
+func ValidateDenyInviteRequest(req *notesv1.DenyInviteRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.InviteId, validation.Required),
+	)
+}
+
+func ValidateGetInviteRequest(req *notesv1.GetInviteRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.InviteId, validation.Required),
+	)
+}
+
+func ValidateRevokeInviteRequest(req *notesv1.RevokeInviteRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.InviteId, validation.Required),
+	)
+}
+
+func ValidateListInviteRequest(req *notesv1.ListInvitesRequest) error {
+	return validation.ValidateStruct(req)
+}


### PR DESCRIPTION
#### Description

Just every endpoint implemented with unit tests
If you're interested in mongodb aggregations, look at ListInvites (lol)
`NOTE`@`models/mongo/groups.go:346`

#### Changelog

- [ENHANCEMENT] Every InviteGroup endpoint and unittests
- [ENHANCEMENT] Cool shits (wow bson:inline) 
[.](https://youtu.be/oLdv17DfATI)
