### PR TITLE
Activities implementation

### DIFF
--- a/activities.go
+++ b/activities.go
@@ -30,8 +30,7 @@ func (srv *groupsAPI) ListActivities(ctx context.Context, req *notesv1.ListActiv
 
 	activities, err := srv.activities.ListActivitiesInternal(ctx,
 		&models.ManyActivitiesFilter{GroupID: req.GroupId},
-		&models.ListOptions{Limit: int32(req.Limit), Offset: int32(req.Offset)},
-		token.AccountID)
+		&models.ListOptions{Limit: int32(req.Limit), Offset: int32(req.Offset)})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
@@ -56,7 +55,7 @@ func (srv *groupsAPI) GetActivity(ctx context.Context, req *notesv1.GetActivityR
 		return nil, statusFromModelError(err)
 	}
 
-	activity, err := srv.activities.GetActivityInternal(ctx, &models.OneActivityFilter{GroupID: req.GroupId, ActivityId: req.ActivityId}, token.AccountID)
+	activity, err := srv.activities.GetActivityInternal(ctx, &models.OneActivityFilter{GroupID: req.GroupId, ActivityId: req.ActivityId})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}

--- a/activities.go
+++ b/activities.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"notes-service/models"
+	notesv1 "notes-service/protorepo/noted/notes/v1"
+	"notes-service/validators"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func (srv *groupsAPI) ListActivities(ctx context.Context, req *notesv1.ListActivitiesRequest) (*notesv1.ListActivitiesResponse, error) {
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateListActivitiesRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Check user is part of the group.
+	_, err = srv.groups.GetGroup(ctx, &models.OneGroupFilter{GroupID: req.GroupId}, token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	activities, err := srv.activities.ListActivitiesInternal(ctx,
+		&models.ManyActivitiesFilter{GroupID: req.GroupId},
+		&models.ListOptions{Limit: int32(req.Limit), Offset: int32(req.Offset)},
+		token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	return &notesv1.ListActivitiesResponse{Activities: modelsGroupActivitiesToProtobufGroupActivities(activities)}, nil
+}
+
+func (srv *groupsAPI) GetActivity(ctx context.Context, req *notesv1.GetActivityRequest) (*notesv1.GetActivityResponse, error) {
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateGetActivityRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Check user is part of the group.
+	_, err = srv.groups.GetGroup(ctx, &models.OneGroupFilter{GroupID: req.GroupId}, token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	activity, err := srv.activities.GetActivityInternal(ctx, &models.OneActivityFilter{GroupID: req.GroupId, ActivityId: req.ActivityId}, token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	return &notesv1.GetActivityResponse{Activity: modelsGroupActivityToProtobufGroupActivity(activity)}, nil
+}
+
+func modelsGroupActivitiesToProtobufGroupActivities(activities []*models.Activity) []*notesv1.GroupActivity {
+	protoActivities := make([]*notesv1.GroupActivity, len(activities))
+
+	for i := range activities {
+		protoActivities[i] = modelsGroupActivityToProtobufGroupActivity(activities[i])
+	}
+
+	return protoActivities
+}
+
+func modelsGroupActivityToProtobufGroupActivity(activity *models.Activity) *notesv1.GroupActivity {
+	return &notesv1.GroupActivity{
+		Id:        activity.ID,
+		GroupId:   activity.GroupID,
+		Type:      string(activity.Type),
+		Event:     activity.Event,
+		CreatedAt: timestamppb.New(activity.CreatedAt),
+	}
+}

--- a/activities_test.go
+++ b/activities_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"notes-service/models"
+	notesv1 "notes-service/protorepo/noted/notes/v1"
+	"time"
+
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivitiesSuite(t *testing.T) {
+	tu := newTestUtilsOrDie(t)
+	gabi := newTestAccount(t, tu)
+	diego := newTestAccount(t, tu)
+	stranger := newTestAccount(t, tu)
+	gabiGroup := newTestGroup(t, tu, gabi, diego)
+
+	t.Run("get-activity", func(t *testing.T) {
+		before := time.Now()
+		activity, err := tu.activitiesRepository.CreateActivityInternal(gabi.Context, &models.ActivityPayload{
+			GroupID: gabiGroup.ID,
+			Type:    models.NoteAdded,
+			Event:   "New event content",
+		})
+		after := time.Now()
+		res, err := tu.groups.GetActivity(gabi.Context, &notesv1.GetActivityRequest{
+			GroupId:    gabiGroup.ID,
+			ActivityId: activity.ID,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, string(models.NoteAdded), res.Activity.Type)
+		require.Equal(t, "New event content", res.Activity.Event)
+		require.GreaterOrEqual(t, res.Activity.CreatedAt.AsTime().Unix(), before.Unix())
+		require.LessOrEqual(t, res.Activity.CreatedAt.AsTime().Unix(), after.Unix())
+	})
+
+	t.Run("stranger-cannot-get-activity", func(t *testing.T) {
+		activity, err := tu.activitiesRepository.CreateActivityInternal(gabi.Context, &models.ActivityPayload{
+			GroupID: gabiGroup.ID,
+			Type:    models.NoteAdded,
+			Event:   "New event content",
+		})
+		res, err := tu.groups.GetActivity(stranger.Context, &notesv1.GetActivityRequest{
+			GroupId:    gabiGroup.ID,
+			ActivityId: activity.ID,
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("cannot-get-activity-because-of-validators", func(t *testing.T) {
+		activity, err := tu.activitiesRepository.CreateActivityInternal(gabi.Context, &models.ActivityPayload{
+			GroupID: gabiGroup.ID,
+			Type:    models.NoteAdded,
+			Event:   "New event content",
+		})
+
+		res, err := tu.groups.GetActivity(stranger.Context, &notesv1.GetActivityRequest{})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		res, err = tu.groups.GetActivity(stranger.Context, &notesv1.GetActivityRequest{
+			GroupId: gabiGroup.ID,
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		res, err = tu.groups.GetActivity(stranger.Context, &notesv1.GetActivityRequest{
+			ActivityId: activity.ID,
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("list-activities", func(t *testing.T) {
+		res, err := tu.groups.ListActivities(gabi.Context, &notesv1.ListActivitiesRequest{
+			GroupId: gabiGroup.ID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, 4, len(res.Activities))
+	})
+
+	t.Run("stanger-cannot-list-activities", func(t *testing.T) {
+		res, err := tu.groups.ListActivities(stranger.Context, &notesv1.ListActivitiesRequest{
+			GroupId: gabiGroup.ID,
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("cannot-list-activities-because-of-validators", func(t *testing.T) {
+		res, err := tu.groups.ListActivities(gabi.Context, &notesv1.ListActivitiesRequest{})
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		res, err = tu.groups.ListActivities(gabi.Context, &notesv1.ListActivitiesRequest{
+			GroupId: "",
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+}

--- a/groups.go
+++ b/groups.go
@@ -160,12 +160,70 @@ func (srv *groupsAPI) ListGroups(ctx context.Context, req *notesv1.ListGroupsReq
 	return &notesv1.ListGroupsResponse{Groups: modelsGroupsToProtobufGroups(groups)}, nil
 }
 
+func (srv *groupsAPI) ListActivities(ctx context.Context, req *notesv1.ListActivitiesRequest) (*notesv1.ListActivitiesResponse, error) {
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateListActivitiesRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	activities, err := srv.groups.ListActivities(ctx, &models.ManyActivitiesFilter{GroupID: req.GroupId}, token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	return &notesv1.ListActivitiesResponse{Activities: modelsGroupActivitiesToProtobufGroupActivities(activities)}, nil
+}
+
+func (srv *groupsAPI) GetActivity(ctx context.Context, req *notesv1.GetActivityRequest) (*notesv1.GetActivityResponse, error) {
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateGetActivityRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	activity, err := srv.groups.GetActivity(ctx, &models.OneActivityFilter{GroupID: req.GroupId, ActivityId: req.ActivityId}, token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	return &notesv1.GetActivitiesResponse{Activity: modelsGroupActivityToProtobufGroupActivity(activity)}, nil
+}
+
 func (srv *groupsAPI) authenticate(ctx context.Context) (*auth.Token, error) {
 	token, err := srv.auth.TokenFromContext(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "invalid token")
 	}
 	return token, nil
+}
+
+func modelsGroupActivitiesToProtobufGroupActivities(activities []*models.GroupActivity) []*notesv1.GroupActivity {
+	protoActivities := make([]*notesv1.GroupActivity, len(activities))
+
+	for i := range activities {
+		protoActivities[i] = modelsGroupActivityToProtobufGroupActivity(activities[i])
+	}
+
+	return protoActivities
+}
+
+func modelsGroupActivityToProtobufGroupActivity(activity *models.GroupActivity) *notesv1.GroupActivity {
+	return &notesv1.GroupActivity{
+		Id:        activity.ID,
+		GroupId:   activity.GroupID,
+		Type:      activity.Type,
+		Event:     activity.Event,
+		CreatedAt: timestamppb.New(activity.CreatedAt),
+	}
 }
 
 func modelsGroupToPublicProtobufGroup(group *models.Group) *notesv1.Group {
@@ -194,6 +252,7 @@ func modelsGroupToProtobufGroup(group *models.Group) *notesv1.Group {
 	var invites []*notesv1.GroupInvite = nil
 	var inviteLinks []*notesv1.GroupInviteLink = nil
 	var conversations []*notesv1.GroupConversation = nil
+	/*activities*/
 
 	if group.Members != nil {
 		members = make([]*notesv1.GroupMember, len(*group.Members))

--- a/invites.go
+++ b/invites.go
@@ -70,6 +70,12 @@ func (srv *groupsAPI) AcceptInvite(ctx context.Context, req *notesv1.AcceptInvit
 		return nil, statusFromModelError(err)
 	}
 
+	srv.activities.CreateActivityInternal(ctx, &models.ActivityPayload{
+		GroupID: req.GroupId,
+		Type:    models.MemberJoined,
+		Event:   "<userId:" + member.AccountID + "> joined the group <groupID" + req.GroupId + ">.",
+	})
+
 	return &notesv1.AcceptInviteResponse{Member: modelsMemberToProtobufMember(member)}, nil
 }
 

--- a/members.go
+++ b/members.go
@@ -74,6 +74,12 @@ func (srv *groupsAPI) RemoveMember(ctx context.Context, req *notesv1.RemoveMembe
 		return nil, statusFromModelError(err)
 	}
 
+	srv.activities.CreateActivityInternal(ctx, &models.ActivityPayload{
+		GroupID: req.GroupId,
+		Type:    models.MemberRemoved,
+		Event:   "<userID:" + req.AccountId + "> leaved the group <groupID:" + req.GroupId + ">.",
+	})
+
 	return &notesv1.RemoveMemberResponse{}, nil
 }
 

--- a/models/activities.go
+++ b/models/activities.go
@@ -37,7 +37,7 @@ type Activity struct {
 }
 
 type ActivitiesRepository interface {
-	ListActivitiesInternal(ctx context.Context, filter *ManyActivitiesFilter, lo *ListOptions, accountID string) ([]*Activity, error)
-	GetActivityInternal(ctx context.Context, filter *OneActivityFilter, accountID string) (*Activity, error)
+	ListActivitiesInternal(ctx context.Context, filter *ManyActivitiesFilter, lo *ListOptions) ([]*Activity, error)
+	GetActivityInternal(ctx context.Context, filter *OneActivityFilter) (*Activity, error)
 	CreateActivityInternal(ctx context.Context, payload *ActivityPayload) (*Activity, error)
 }

--- a/models/activities.go
+++ b/models/activities.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"context"
+	"time"
+)
+
+type ActivityType string
+
+const (
+	NoteAdded     ActivityType = "ADD-NOTE"
+	MemberJoined  ActivityType = "ADD-MEMBER"
+	MemberRemoved ActivityType = "REMOVE-MEMBER"
+)
+
+type ActivityPayload struct {
+	GroupID string
+	Type    ActivityType
+	Event   string
+}
+
+type OneActivityFilter struct {
+	GroupID    string
+	ActivityId string
+}
+
+type ManyActivitiesFilter struct {
+	GroupID string
+}
+
+type Activity struct {
+	ID        string    `json:"id" bson:"_id"`
+	GroupID   string    `json:"groupId" bson:"groupId"`
+	Type      string    `json:"type" bson:"type"`
+	Event     string    `json:"event" bson:"event"`
+	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+}
+
+type ActivitiesRepository interface {
+	ListActivitiesInternal(ctx context.Context, filter *ManyActivitiesFilter, lo *ListOptions, accountID string) ([]*Activity, error)
+	GetActivityInternal(ctx context.Context, filter *OneActivityFilter, accountID string) (*Activity, error)
+	CreateActivityInternal(ctx context.Context, payload *ActivityPayload) (*Activity, error)
+}

--- a/models/groups.go
+++ b/models/groups.go
@@ -308,7 +308,7 @@ type GroupsRepository interface {
 	UseInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) (*GroupMember, error)
 
 	// Activities
-	ListActivities(ctx context.Context, filter *ManyActivitiesFilter) (*[]GroupActivity, error)
-	GetActivity(ctx context.Context, filter *OneActivityFilter) (*GroupActivity, error)
+	ListActivities(ctx context.Context, filter *ManyActivitiesFilter, accountID string) ([]*GroupActivity, error)
+	GetActivity(ctx context.Context, filter *OneActivityFilter, accountID string) (*GroupActivity, error)
 	CreateActivityInternal(ctx context.Context, payload *ActivityPayload) error
 }

--- a/models/groups.go
+++ b/models/groups.go
@@ -42,12 +42,9 @@ type GroupInviteLink struct {
 	ValidUntil           time.Time `json:"validUntil" bson:"validUntil"`
 }
 
-type GroupActivity struct {
-	ID        string    `json:"id" bson:"_id"`
-	GroupID   string    `json:"groupId" bson:"groupId"`
-	Type      string    `json:"type" bson:"type"`
-	Event     string    `json:"event" bson:"event"`
-	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+type ListInvitesResult struct {
+	GroupInvite `json:"inline" bson:"inline"`
+	GroupID     string `json:"groupId" bson:"groupId"`
 }
 
 type Group struct {
@@ -62,7 +59,6 @@ type Group struct {
 	Members            *[]GroupMember       `json:"members,omitempty" bson:"members,omitempty"`
 	Invites            *[]GroupInvite       `json:"invites,omitempty" bson:"invites,omitempty"`
 	InviteLinks        *[]GroupInviteLink   `json:"inviteLinks,omitempty" bson:"inviteLinks,omitempty"`
-	Activities         *[]GroupActivity     `json:"activities,omitempty" bson:"activities,omitempty"`
 }
 
 func (group *Group) FindConversation(id string) *GroupConversation {
@@ -138,18 +134,6 @@ func (group *Group) FindInviteLinkByCode(code string) *GroupInviteLink {
 	return nil
 }
 
-func (group *Group) FindActivity(activityId string) *GroupActivity {
-	if group.Activities == nil {
-		return nil
-	}
-	for i := 0; i < len(*group.Activities); i++ {
-		if (*group.Activities)[i].ID == activityId {
-			return &(*group.Activities)[i]
-		}
-	}
-	return nil
-}
-
 type OneGroupFilter struct {
 	GroupID string
 }
@@ -191,15 +175,6 @@ type ManyInvitesFilter struct {
 	// (Optional) List all invites destined to this user.
 	RecipientAccountID string
 	// (Optional) List all invites in this group.
-	GroupID string
-}
-
-type OneActivityFilter struct {
-	GroupID    string
-	ActivityId string
-}
-
-type ManyActivitiesFilter struct {
 	GroupID string
 }
 
@@ -254,17 +229,6 @@ type UpdateGroupConversationMessagePayload struct {
 	Content string
 }
 
-type ActivityPayload struct {
-	GroupID string `json:"groupId" bson:"groupId"`
-	Type    string `json:"type" bson:"type"`
-	Event   string `json:"event" bson:"event"`
-}
-
-type ListInvitesResult struct {
-	GroupInvite `json:"inline" bson:"inline"`
-	GroupID     string `json:"groupId" bson:"groupId"`
-}
-
 // GroupsRepository encapsulates the persistence layer that stores groups.
 // Every endpoint is translated into a single (hopefully) optimized query on
 // groups.
@@ -306,9 +270,4 @@ type GroupsRepository interface {
 	GetInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) (*GroupInviteLink, error)
 	RevokeInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) error
 	UseInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) (*GroupMember, error)
-
-	// Activities
-	ListActivities(ctx context.Context, filter *ManyActivitiesFilter, accountID string) ([]*GroupActivity, error)
-	GetActivity(ctx context.Context, filter *OneActivityFilter, accountID string) (*GroupActivity, error)
-	CreateActivityInternal(ctx context.Context, payload *ActivityPayload) error
 }

--- a/models/groups.go
+++ b/models/groups.go
@@ -42,6 +42,14 @@ type GroupInviteLink struct {
 	ValidUntil           time.Time `json:"validUntil" bson:"validUntil"`
 }
 
+type GroupActivity struct {
+	ID        string    `json:"id" bson:"_id"`
+	GroupID   string    `json:"groupId" bson:"groupId"`
+	Type      string    `json:"type" bson:"type"`
+	Event     string    `json:"event" bson:"event"`
+	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+}
+
 type Group struct {
 	ID                 string               `json:"id" bson:"_id"`
 	Name               string               `json:"name" bson:"name"`
@@ -54,6 +62,7 @@ type Group struct {
 	Members            *[]GroupMember       `json:"members,omitempty" bson:"members,omitempty"`
 	Invites            *[]GroupInvite       `json:"invites,omitempty" bson:"invites,omitempty"`
 	InviteLinks        *[]GroupInviteLink   `json:"inviteLinks,omitempty" bson:"inviteLinks,omitempty"`
+	Activities         *[]GroupActivity     `json:"activities,omitempty" bson:"activities,omitempty"`
 }
 
 func (group *Group) FindConversation(id string) *GroupConversation {
@@ -129,6 +138,18 @@ func (group *Group) FindInviteLinkByCode(code string) *GroupInviteLink {
 	return nil
 }
 
+func (group *Group) FindActivity(activityId string) *GroupActivity {
+	if group.Activities == nil {
+		return nil
+	}
+	for i := 0; i < len(*group.Activities); i++ {
+		if (*group.Activities)[i].ID == activityId {
+			return &(*group.Activities)[i]
+		}
+	}
+	return nil
+}
+
 type OneGroupFilter struct {
 	GroupID string
 }
@@ -170,6 +191,15 @@ type ManyInvitesFilter struct {
 	// (Optional) List all invites destined to this user.
 	RecipientAccountID string
 	// (Optional) List all invites in this group.
+	GroupID string
+}
+
+type OneActivityFilter struct {
+	GroupID    string
+	ActivityId string
+}
+
+type ManyActivitiesFilter struct {
 	GroupID string
 }
 
@@ -224,6 +254,12 @@ type UpdateGroupConversationMessagePayload struct {
 	Content string
 }
 
+type ActivityPayload struct {
+	GroupID string `json:"groupId" bson:"groupId"`
+	Type    string `json:"type" bson:"type"`
+	Event   string `json:"event" bson:"event"`
+}
+
 type ListInvitesResult struct {
 	GroupInvite `json:"inline" bson:"inline"`
 	GroupID     string `json:"groupId" bson:"groupId"`
@@ -270,4 +306,9 @@ type GroupsRepository interface {
 	GetInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) (*GroupInviteLink, error)
 	RevokeInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) error
 	UseInviteLink(ctx context.Context, filter *OneInviteLinkFilter, accountID string) (*GroupMember, error)
+
+	// Activities
+	ListActivities(ctx context.Context, filter *ManyActivitiesFilter) (*[]GroupActivity, error)
+	GetActivity(ctx context.Context, filter *OneActivityFilter) (*GroupActivity, error)
+	CreateActivityInternal(ctx context.Context, payload *ActivityPayload) error
 }

--- a/models/mongo/activities.go
+++ b/models/mongo/activities.go
@@ -30,7 +30,7 @@ func NewActivitiesRepository(db *mongo.Database, logger *zap.Logger) models.Acti
 	}
 }
 
-func (repo *activitiesRepository) ListActivitiesInternal(ctx context.Context, filter *models.ManyActivitiesFilter, lo *models.ListOptions, accountID string) ([]*models.Activity, error) {
+func (repo *activitiesRepository) ListActivitiesInternal(ctx context.Context, filter *models.ManyActivitiesFilter, lo *models.ListOptions) ([]*models.Activity, error) {
 	activities := make([]*models.Activity, 0)
 
 	query := bson.D{
@@ -45,7 +45,7 @@ func (repo *activitiesRepository) ListActivitiesInternal(ctx context.Context, fi
 	return activities, nil
 }
 
-func (repo *activitiesRepository) GetActivityInternal(ctx context.Context, filter *models.OneActivityFilter, accountID string) (*models.Activity, error) {
+func (repo *activitiesRepository) GetActivityInternal(ctx context.Context, filter *models.OneActivityFilter) (*models.Activity, error) {
 	activity := &models.Activity{}
 
 	query := bson.D{

--- a/models/mongo/activities.go
+++ b/models/mongo/activities.go
@@ -1,0 +1,79 @@
+package mongo
+
+import (
+	"context"
+	"notes-service/models"
+	"time"
+
+	"github.com/jaevor/go-nanoid"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
+)
+
+type activitiesRepository struct {
+	repository
+}
+
+func NewActivitiesRepository(db *mongo.Database, logger *zap.Logger) models.ActivitiesRepository {
+	newUUID, err := nanoid.Standard(21)
+	if err != nil {
+		panic(err)
+	}
+
+	return &activitiesRepository{
+		repository: repository{
+			logger:  logger.Named("mongo").Named("activities"),
+			coll:    db.Collection("activities"),
+			newUUID: newUUID,
+		},
+	}
+}
+
+func (repo *activitiesRepository) ListActivitiesInternal(ctx context.Context, filter *models.ManyActivitiesFilter, lo *models.ListOptions, accountID string) ([]*models.Activity, error) {
+	activities := make([]*models.Activity, 0)
+
+	query := bson.D{
+		{Key: "groupId", Value: filter.GroupID},
+	}
+
+	err := repo.find(ctx, query, &activities, lo)
+	if err != nil {
+		return nil, err
+	}
+
+	return activities, nil
+}
+
+func (repo *activitiesRepository) GetActivityInternal(ctx context.Context, filter *models.OneActivityFilter, accountID string) (*models.Activity, error) {
+	activity := &models.Activity{}
+
+	query := bson.D{
+		{Key: "_id", Value: filter.ActivityId},
+		{Key: "groupId", Value: filter.GroupID},
+	}
+
+	err := repo.findOne(ctx, query, activity)
+	if err != nil {
+		return nil, err
+	}
+
+	return activity, nil
+}
+
+func (repo *activitiesRepository) CreateActivityInternal(ctx context.Context, payload *models.ActivityPayload) (*models.Activity, error) {
+	activity := &models.Activity{
+		ID:        repo.newUUID(),
+		GroupID:   payload.GroupID,
+		Type:      string(payload.Type),
+		Event:     payload.Event,
+		CreatedAt: time.Now(),
+	}
+
+	err := repo.insertOne(ctx, activity)
+	if err != nil {
+		return nil, err
+	}
+
+	return activity, nil
+}

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -48,6 +48,7 @@ func (repo *groupsRepository) CreateGroup(ctx context.Context, payload *models.C
 		},
 		Invites:     &[]models.GroupInvite{},
 		InviteLinks: &[]models.GroupInviteLink{},
+		Activities:  &[]models.GroupActivity{},
 	}
 
 	err := repo.insertOne(ctx, group)
@@ -71,6 +72,7 @@ func (repo *groupsRepository) CreateWorkspace(ctx context.Context, payload *mode
 		Members:            nil,
 		Invites:            nil,
 		InviteLinks:        nil,
+		Activities:         nil,
 	}
 
 	err := repo.insertOne(ctx, workspace)
@@ -535,4 +537,75 @@ func (repo *groupsRepository) RevokeInviteLink(ctx context.Context, filter *mode
 
 func (repo *groupsRepository) UseInviteLink(ctx context.Context, filter *models.OneInviteLinkFilter, accountID string) (*models.GroupMember, error) {
 	return nil, nil
+}
+
+func (repo *groupsRepository) ListActivities(ctx context.Context, filter *models.ManyActivitiesFilter) (*[]models.GroupActivity, error) {
+	group := &models.Group{}
+
+	query := bson.D{
+		{Key: "_id", Value: filter.GroupID},
+	}
+
+	err := repo.findOne(ctx, query, group)
+	if err != nil {
+		return nil, err
+	}
+	if len(*group.Activities) == 0 {
+		return nil, models.ErrNotFound
+	}
+
+	return group.Activities, nil
+}
+
+func (repo *groupsRepository) GetActivity(ctx context.Context, filter *models.OneActivityFilter) (*models.GroupActivity, error) {
+	group := &models.Group{}
+	query := bson.D{
+		{Key: "_id", Value: filter.GroupID},
+		{Key: "$or", Value: bson.A{
+			bson.D{
+				{Key: "activities", Value: bson.D{
+					{Key: "$elemMatch", Value: bson.D{
+						{Key: "id", Value: filter.ActivityId},
+					}},
+				}},
+			},
+		}},
+	}
+
+	err := repo.findOne(ctx, query, group)
+	if err != nil {
+		return nil, err
+	}
+	if len(*group.Activities) == 0 {
+		return nil, models.ErrNotFound
+	}
+
+	return group.FindActivity(filter.ActivityId), nil
+}
+
+func (repo *groupsRepository) CreateActivityInternal(ctx context.Context, payload *models.ActivityPayload) error {
+	group := &models.Group{}
+	activityID := repo.newUUID()
+
+	query := bson.D{
+		{Key: "_id", Value: payload.GroupID},
+	}
+	update := bson.D{
+		{Key: "$push", Value: bson.D{
+			{Key: "activities", Value: &models.GroupActivity{
+				ID:        activityID,
+				GroupID:   payload.GroupID,
+				Type:      payload.Type,
+				Event:     payload.Event,
+				CreatedAt: time.Now(),
+			}},
+		}},
+	}
+
+	err := repo.findOneAndUpdate(ctx, query, update, group)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/notes.go
+++ b/notes.go
@@ -27,8 +27,9 @@ type notesAPI struct {
 	language   language.Service
 	background background.Service
 
-	notes  models.NotesRepository
-	groups models.GroupsRepository
+	notes      models.NotesRepository
+	groups     models.GroupsRepository
+	activities models.ActivitiesRepository
 }
 
 var _ notesv1.NotesAPIServer = &notesAPI{}
@@ -70,6 +71,12 @@ func (srv *notesAPI) CreateNote(ctx context.Context, req *notesv1.CreateNoteRequ
 		SecondsToDebounce:             900,
 		CancelProcessOnSameIdentifier: true,
 		RepeatProcess:                 false,
+	})
+
+	srv.activities.CreateActivityInternal(ctx, &models.ActivityPayload{
+		GroupID: note.GroupID,
+		Type:    models.NoteAdded,
+		Event:   "<userID:" + note.AuthorAccountID + "> has added the note <noteID:" + note.ID + "> in the folder <folderID" + "" + ">.",
 	})
 
 	return &notesv1.CreateNoteResponse{Note: modelsNoteToProtobufNote(note)}, nil

--- a/server.go
+++ b/server.go
@@ -35,8 +35,9 @@ type server struct {
 
 	mongoDB *mongo.Database
 
-	notesRepository  models.NotesRepository
-	groupsRepository models.GroupsRepository
+	notesRepository      models.NotesRepository
+	groupsRepository     models.GroupsRepository
+	activitiesRepository models.ActivitiesRepository
 
 	notesAPI  notesv1.NotesAPIServer
 	groupsAPI notesv1.GroupsAPIServer
@@ -132,10 +133,11 @@ func (s *server) initBackgroundService() {
 
 func (s *server) initGroupsAPI() {
 	s.groupsAPI = &groupsAPI{
-		auth:   s.authService,
-		logger: s.logger,
-		notes:  s.notesRepository,
-		groups: s.groupsRepository,
+		auth:       s.authService,
+		logger:     s.logger,
+		notes:      s.notesRepository,
+		groups:     s.groupsRepository,
+		activities: s.activitiesRepository,
 	}
 }
 
@@ -145,6 +147,7 @@ func (s *server) initNotesAPI() {
 		logger:     s.logger,
 		notes:      s.notesRepository,
 		groups:     s.groupsRepository,
+		activities: s.activitiesRepository,
 		language:   s.languageService,
 		background: s.backgroundService,
 	}
@@ -162,6 +165,7 @@ func (s *server) initRepositories() {
 	must(err, "could not instantiate mongo database")
 	s.notesRepository = mongo.NewNotesRepository(s.mongoDB.DB, s.logger)
 	s.groupsRepository = mongo.NewGroupsRepository(s.mongoDB.DB, s.logger)
+	s.activitiesRepository = mongo.NewActivitiesRepository(s.mongoDB.DB, s.logger)
 }
 
 func must(err error, msg string) {

--- a/validators/activities.go
+++ b/validators/activities.go
@@ -1,0 +1,20 @@
+package validators
+
+import (
+	notesv1 "notes-service/protorepo/noted/notes/v1"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+func ValidateListActivitiesRequest(req *notesv1.ListActivitiesRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required, validation.Required),
+	)
+}
+
+func ValidateGetActivityRequest(req *notesv1.GetActivityRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.ActivityId, validation.Required),
+	)
+}

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -36,3 +36,16 @@ func ValidateListGroupsRequest(req *notesv1.ListGroupsRequest) error {
 		validation.Field(&req.AccountId, validation.Required),
 	)
 }
+
+func ValidateListActivitiesRequest(req *notesv1.ListActivitiesRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required, validation.Required),
+	)
+}
+
+func ValidateGetActivityRequest(req *notesv1.GetActivityRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.ActivityId, validation.Required),
+	)
+}

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -36,16 +36,3 @@ func ValidateListGroupsRequest(req *notesv1.ListGroupsRequest) error {
 		validation.Field(&req.AccountId, validation.Required),
 	)
 }
-
-func ValidateListActivitiesRequest(req *notesv1.ListActivitiesRequest) error {
-	return validation.ValidateStruct(req,
-		validation.Field(&req.GroupId, validation.Required, validation.Required),
-	)
-}
-
-func ValidateGetActivityRequest(req *notesv1.GetActivityRequest) error {
-	return validation.ValidateStruct(req,
-		validation.Field(&req.GroupId, validation.Required),
-		validation.Field(&req.ActivityId, validation.Required),
-	)
-}


### PR DESCRIPTION
#### Description

Activity are going to be saved in backend on : 
- New note added to a group/workspace folder (`CreateNote()` endpoint)
- New member join a group (`AcceptInvite()` endpoint)
- Member leave a group (`RemoveMember()` endpoint)
_(If you think we should create activities for other events don't hesitate to write a comment please)_

An event like : ```
"<userID:123> has added <noteID:3889> in <folderID:1092>"```Is going to be saved in an `Activity` object in databse collection called `activities`.

Fixes #40 

#### Changelog

New endpoints :
- `ListActivities()`
- `GetActivity()`

New mongo function :
- `CreateActivityInternal()` (will be call on enpoints so only by the notes-service)
- `GetActivityInternal()` (cannot check if the member accountID belongs to the groupID so called internal)
- `ListActivitiesInternal()` (cannot check if the member accountID belongs to the groupID so called internal)

New unit tests : 
In activities_tests.go

New repository and collection : 
In server.go
