### PR TITLE
Update a note's blocks through `UpdateNote` endpoint

### DIFF
--- a/models/notes.go
+++ b/models/notes.go
@@ -112,7 +112,10 @@ type UpdateBlockPayload struct {
 }
 
 type UpdateNotePayload struct {
-	Title    string    `json:"title,omitempty" bson:"title,omitempty"`
+	Title  string       `json:"title,omitempty" bson:"title,omitempty"`
+	Blocks *[]NoteBlock `json:"blocks,omitempty" bson:"blocks,omitempty"`
+
+	// TODO: Remove
 	Keywords []Keyword `json:"keywords" bson:"keywords"`
 }
 

--- a/notes.go
+++ b/notes.go
@@ -119,13 +119,29 @@ func (srv *notesAPI) UpdateNote(ctx context.Context, req *notesv1.UpdateNoteRequ
 
 	note, err := srv.notes.UpdateNote(ctx,
 		&models.OneNoteFilter{GroupID: req.GroupId, NoteID: req.NoteId},
-		&models.UpdateNotePayload{Title: req.Note.Title},
+		updateNotePayloadFromUpdateNoteRequest(req),
 		token.AccountID)
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
 
 	return &notesv1.UpdateNoteResponse{Note: modelsNoteToProtobufNote(note)}, nil
+}
+
+func updateNotePayloadFromUpdateNoteRequest(req *notesv1.UpdateNoteRequest) *models.UpdateNotePayload {
+	payload := &models.UpdateNotePayload{}
+
+	for _, path := range req.UpdateMask.Paths {
+		switch path {
+		case "title":
+			payload.Title = req.Note.Title
+		case "blocks":
+			blocks := protobufBlocksToModelsBlocks(req.Note.Blocks)
+			payload.Blocks = &blocks
+		}
+	}
+
+	return payload
 }
 
 func (srv *notesAPI) DeleteNote(ctx context.Context, req *notesv1.DeleteNoteRequest) (*notesv1.DeleteNoteResponse, error) {
@@ -293,6 +309,10 @@ var protobufFormatToFormatter = map[notesv1.NoteExportFormat]func(*notesv1.Note)
 }
 
 func protobufBlocksToModelsBlocks(blocks []*notesv1.Block) []models.NoteBlock {
+	if blocks == nil {
+		return nil
+	}
+
 	modelsBlocks := make([]models.NoteBlock, len(blocks))
 
 	for i := range blocks {

--- a/notes_test.go
+++ b/notes_test.go
@@ -384,6 +384,21 @@ func TestNotesSuite(t *testing.T) {
 		require.Nil(t, res)
 	})
 
+	t.Run("owner-cannot-update-note-with-invalid-field-mask-path", func(t *testing.T) {
+		res, err := tu.notes.UpdateNote(edouard.Context, &notesv1.UpdateNoteRequest{
+			NoteId:  edouardNote.ID,
+			GroupId: edouardGroup.ID,
+			Note: &notesv1.Note{
+				Title: "Brand New Title",
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"invalid-field"},
+			},
+		})
+		requireErrorHasGRPCCode(t, codes.InvalidArgument, err)
+		require.Nil(t, res)
+	})
+
 	t.Run("member-cannot-delete-note", func(t *testing.T) {
 		res, err := tu.notes.DeleteNote(edouard.Context, &notesv1.DeleteNoteRequest{
 			GroupId: maximeNote.Group.ID,

--- a/validators/notes.go
+++ b/validators/notes.go
@@ -24,11 +24,29 @@ func ValidateUpdateNoteRequest(req *notespb.UpdateNoteRequest) error {
 	err := validation.ValidateStruct(req,
 		validation.Field(&req.GroupId, validation.Required),
 		validation.Field(&req.NoteId, validation.Required),
+		validation.Field(&req.UpdateMask, validation.Required),
 	)
 	if err != nil {
 		return err
 	}
-	return validation.Validate(req.Note.Title, validation.Length(0, 64))
+
+	// Check update mask is not empty.
+	err = validation.Validate(&req.UpdateMask.Paths, validation.Required)
+	if err != nil {
+		return err
+	}
+
+	// Check update mask paths are set.
+	for _, path := range req.UpdateMask.Paths {
+		switch path {
+		case "title":
+			err = validation.Validate(&req.Note.Title, validation.Required, validation.Length(1, 64))
+		case "blocks":
+			err = validation.Validate(&req.Note.Blocks, validation.NotNil)
+		}
+	}
+
+	return err
 }
 
 func ValidateDeleteNoteRequest(req *notespb.DeleteNoteRequest) error {

--- a/validators/notes.go
+++ b/validators/notes.go
@@ -43,6 +43,8 @@ func ValidateUpdateNoteRequest(req *notespb.UpdateNoteRequest) error {
 			err = validation.Validate(&req.Note.Title, validation.Required, validation.Length(1, 64))
 		case "blocks":
 			err = validation.Validate(&req.Note.Blocks, validation.NotNil)
+		default:
+			return validation.NewError("update_mask", "update to "+path+" is forbidden")
 		}
 	}
 


### PR DESCRIPTION
#### Description

The front-end needs to be able to overwrite a note's blocks array. Added the ability to edit `note.blocks` in `NotesAPI.UpdateNote`.

#### Changelog

- [ENHANCEMENT] Add ability to edit `note.blocks` in `NotesAPI.UpdateNote` endpoint.
