### PR TITLE
Fix sanitize new line on markdown export note 

### DIFF
--- a/exports/markdown.go
+++ b/exports/markdown.go
@@ -37,6 +37,10 @@ func imageBlockToMarkdown(b *notespb.Block) string {
 }
 
 func sanitizeNewLines(str *string) {
+	if len(*str) == 0 {
+		*str = "\n"
+		return
+	}
 	*str = strings.ReplaceAll(*str, "\r\n", "\n")
 	if (*str)[len(*str)-1] != '\n' {
 		*str = *str + "\n"


### PR DESCRIPTION
I fixed the sanitize new line function when the string sent is empty. But it should never happen so weird.