### PR TITLE
Adapt email sending

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Run tests
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/communication/accounts.go
+++ b/communication/accounts.go
@@ -1,0 +1,40 @@
+package communication
+
+import (
+	accountsv1 "notes-service/protorepo/noted/accounts/v1"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type AccountsServiceClient struct {
+	conn     *grpc.ClientConn
+	Accounts accountsv1.AccountsAPIClient
+}
+
+func NewAccountsServiceClient(address string) (*AccountsServiceClient, error) {
+	res := AccountsServiceClient{}
+
+	err := res.Init(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func (c *AccountsServiceClient) Init(address string) error {
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	c.Accounts = accountsv1.NewAccountsAPIClient(c.conn)
+
+	return nil
+}
+
+func (c *AccountsServiceClient) Close() error {
+	return c.conn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20230322041520-c84983bdbf2a // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/s2a-go v0.1.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -46,6 +47,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/noted-eip/noted/mailing-service v0.0.0-20230612112126-a144d6b761c3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomarkdown/markdown v0.0.0-20230322041520-c84983bdbf2a h1:AWZzzFrqyjYlRloN6edwTLTUbKxf5flLXNuTBDm3Ews=
+github.com/gomarkdown/markdown v0.0.0-20230322041520-c84983bdbf2a/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -616,6 +618,8 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/noted-eip/noted/background-service v0.0.0-20230612085710-bb82b35c9b96 h1:yNkb2Fu6iIbdPiwidXm952/J4UQ4tEv+s0yCQczEeSg=
 github.com/noted-eip/noted/background-service v0.0.0-20230612085710-bb82b35c9b96/go.mod h1:ErQ0SpCbWG6OftzL2VppSd/+P5fLnV0wjw0l17BFfJo=
+github.com/noted-eip/noted/mailing-service v0.0.0-20230612112126-a144d6b761c3 h1:TE2d4KVGT0aJda94NoCb35S95osbVCKy9J0tu7N5w5I=
+github.com/noted-eip/noted/mailing-service v0.0.0-20230612112126-a144d6b761c3/go.mod h1:9L2ss3vlrCpuU68PlPWABJWIMBamzoYXN4yt0XjUzgo=
 github.com/pascaldekloe/name v0.0.0-20180628100202-0fd16699aae1/go.mod h1:eD5JxqMiuNYyFNmyY9rkJ/slN8y59oEu4Ei7F8OoKWQ=
 github.com/phpdave11/gofpdf v1.4.2 h1:KPKiIbfwbvC/wOncwhrpRdXVj2CZTCFlw4wnoyjtHfQ=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=

--- a/groups.go
+++ b/groups.go
@@ -5,7 +5,10 @@ import (
 	"notes-service/auth"
 	"notes-service/models"
 
+	"notes-service/communication"
+
 	background "github.com/noted-eip/noted/background-service"
+	mailing "github.com/noted-eip/noted/mailing-service"
 
 	notesv1 "notes-service/protorepo/noted/notes/v1"
 	"notes-service/validators"
@@ -23,6 +26,9 @@ type groupsAPI struct {
 
 	auth       auth.Service
 	background background.Service
+	mailing    mailing.Service
+
+	accountsClient *communication.AccountsServiceClient
 
 	groups     models.GroupsRepository
 	activities models.ActivitiesRepository

--- a/invites.go
+++ b/invites.go
@@ -33,23 +33,25 @@ func (srv *groupsAPI) SendInvite(ctx context.Context, req *notesv1.SendInviteReq
 		return nil, statusFromModelError(err)
 	}
 
-	// SEND EMAIL
-	group, err := srv.groups.GetGroupInternal(ctx, &models.OneGroupFilter{GroupID: req.GroupId})
-	if err == nil {
+	if srv.accountsClient != nil {
+		group, err := srv.groups.GetGroupInternal(ctx, &models.OneGroupFilter{GroupID: req.GroupId})
+		if err != nil {
+			return nil, err
+		}
 		emailInformation := SendGroupInviteMailContent(invite.RecipientAccountID, group.Name, timestamppb.New(invite.ValidUntil))
-
 		accountResponse, err := srv.accountsClient.Accounts.GetAccount(ctx, &accountsv1.GetAccountRequest{
 			AccountId: invite.SenderAccountID,
 		})
-
+		if err != nil {
+			return nil, err
+		}
 		err = srv.mailing.SendEmails(ctx, emailInformation, []string{accountResponse.Account.Email})
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		srv.logger.Warn("GetGroupInternal returned an error : " + err.Error() + "from SendInvite method, could not send email")
+		srv.logger.Warn("SendEmail for invite returned an error because notes service is not connected with the accountsClients : " + err.Error())
 	}
-	// !SEND EMAIL
 
 	return &notesv1.SendInviteResponse{Invite: modelsInviteToProtobufInvite(invite, req.GroupId)}, nil
 }

--- a/invites.go
+++ b/invites.go
@@ -50,7 +50,7 @@ func (srv *groupsAPI) SendInvite(ctx context.Context, req *notesv1.SendInviteReq
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	} else {
-		srv.logger.Warn("SendEmail for invite returned an error because notes service is not connected with the accountsClients : " + err.Error())
+		srv.logger.Warn("SendEmail for invite returned an error because notes service is not connected with the accountsClients")
 	}
 
 	return &notesv1.SendInviteResponse{Invite: modelsInviteToProtobufInvite(invite, req.GroupId)}, nil

--- a/mails_content.go
+++ b/mails_content.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	mailing "github.com/noted-eip/noted/mailing-service"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func SendGroupInviteMailContent(recipientId string, groupName string, validUntil *timestamppb.Timestamp) *mailing.SendEmailsRequest {
+	body := fmt.Sprintf(`<span>Bonjour,<br/>Vous avez été invité à rejoindre le groupe %s.
+	<br/>Veuillez vous connecter à votre profil pour accepter ou refuser l'invitation.
+	<a href="https://noted-eip.vercel.app/profile" style="color: blue">Visitez mon profil (https://noted-eip.vercel.app/profile) </a>
+	<br/>Attention, cette invitation est valable seulement 2 semaines</span>`, groupName)
+
+	return &mailing.SendEmailsRequest{
+		To:      []string{recipientId},
+		Sender:  "noted.organisation@gmail.com",
+		Title:   "Invitation à rejoindre un groupe",
+		Subject: "Vous avez été invité à rejoindre le groupe " + groupName,
+		Body:    body,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,11 +13,13 @@ import (
 var (
 	app = kingpin.New("notes-service", "Notes service for the Noted backend").DefaultEnvars()
 
-	environment   = app.Flag("env", "either development or production").Default(envIsProd).Enum(envIsProd, envIsDev)
-	port          = app.Flag("port", "grpc server port").Default("3000").Int()
-	mongoUri      = app.Flag("mongo-uri", "mongo uri with password to connect client").Default("mongodb://localhost:27017").String()
-	mongoDbName   = app.Flag("mongo-db-name", "name of the mongo database").Default("notes-service").String()
-	jwtPrivateKey = app.Flag("jwt-private-key", "base64 encoded ed25519 private key").Default("SGfCQAb05CtmhEesWxcrfXSQR6JjmEMeyjR7Mo21S60ZDW9VVTUuCvEMlGjlqiw4I/z8T11KqAXexvGIPiuffA==").String()
+	environment        = app.Flag("env", "either development or production").Default(envIsProd).Enum(envIsProd, envIsDev)
+	accountsServiceUrl = app.Flag("accounts-service-url", "address of the accounts-service url to communicate with").Default("accounts.noted.koyeb:3000").String()
+	port               = app.Flag("port", "grpc server port").Default("3000").Int()
+	mongoUri           = app.Flag("mongo-uri", "mongo uri with password to connect client").Default("mongodb://localhost:27017").String()
+	mongoDbName        = app.Flag("mongo-db-name", "name of the mongo database").Default("notes-service").String()
+	jwtPrivateKey      = app.Flag("jwt-private-key", "base64 encoded ed25519 private key").Default("SGfCQAb05CtmhEesWxcrfXSQR6JjmEMeyjR7Mo21S60ZDW9VVTUuCvEMlGjlqiw4I/z8T11KqAXexvGIPiuffA==").String()
+	gmailSuperSecret   = app.Flag("gmail-super-secret", "token to authenticate notes service with noted gmail account").Default("").String()
 )
 
 var (


### PR DESCRIPTION
#### Description

Remplacement du "service" de mailing ancienement mailing.go par le package noted/mailing-service.

Fixes #62 

#### Changelog

Nouveau client `accountClient` dans la `groupsAPI`. Ce client est instancié dans `server.go` puis dans `communication/accounts.go`.
Dans sendInvite un appel a `accountClient` est fait pour récuperer l'email du destinataire. Et un appel a package `maling-service` est fait.
