### PR TITLE
UpdateBlockIndex

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -50,6 +50,43 @@ func (srv *notesAPI) InsertBlock(ctx context.Context, req *notesv1.InsertBlockRe
 	return &notesv1.InsertBlockResponse{Block: modelsBlockToProtobufBlock(block)}, nil
 }
 
+func (srv *notesAPI) UpdateBlockIndex(ctx context.Context, req *notesv1.UpdateBlockIndexRequest) (*notesv1.UpdateBlockIndexResponse, error) {
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateUpdateBlockIndexRequest(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	block, err := srv.notes.GetBlock(ctx,
+		&models.OneBlockFilter{GroupID: req.GroupId, NoteID: req.NoteId, BlockID: req.BlockId},
+		token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+	err = srv.notes.DeleteBlock(ctx,
+		&models.OneBlockFilter{GroupID: req.GroupId, NoteID: req.NoteId, BlockID: req.BlockId},
+		token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+	block, err = srv.notes.InsertBlock(ctx,
+		&models.OneNoteFilter{GroupID: req.GroupId, NoteID: req.NoteId},
+		&models.InsertNoteBlockPayload{
+			Index: uint(req.Index),
+			Block: *block,
+		},
+		token.AccountID)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	return &notesv1.UpdateBlockIndexResponse{Block: modelsBlockToProtobufBlock(block)}, nil
+}
+
 func (srv *notesAPI) UpdateBlock(ctx context.Context, req *notesv1.UpdateBlockRequest) (*notesv1.UpdateBlockResponse, error) {
 	token, err := srv.authenticate(ctx)
 	if err != nil {

--- a/models/mongo/notes.go
+++ b/models/mongo/notes.go
@@ -232,6 +232,21 @@ func (repo *notesRepository) UpdateBlock(ctx context.Context, filter *models.One
 	return note.FindBlock(filter.BlockID), nil
 }
 
+func (repo *notesRepository) GetBlock(ctx context.Context, filter *models.OneBlockFilter, accountID string) (*models.NoteBlock, error) {
+	note := &models.Note{}
+	query := bson.D{
+		{Key: "_id", Value: filter.NoteID},
+		{Key: "groupId", Value: filter.GroupID},
+	}
+
+	err := repo.findOne(ctx, query, note)
+	if err != nil {
+		return nil, err
+	}
+
+	return note.FindBlock(filter.BlockID), nil
+}
+
 func (repo *notesRepository) DeleteBlock(ctx context.Context, filter *models.OneBlockFilter, accountID string) error {
 	note := &models.Note{}
 

--- a/models/notes.go
+++ b/models/notes.go
@@ -148,5 +148,6 @@ type NotesRepository interface {
 	// Blocks
 	InsertBlock(ctx context.Context, filter *OneNoteFilter, payload *InsertNoteBlockPayload, accountID string) (*NoteBlock, error)
 	UpdateBlock(ctx context.Context, filter *OneBlockFilter, payload *UpdateBlockPayload, accountID string) (*NoteBlock, error)
+	GetBlock(ctx context.Context, filter *OneBlockFilter, accountID string) (*NoteBlock, error)
 	DeleteBlock(ctx context.Context, filter *OneBlockFilter, accountID string) error
 }

--- a/validators/blocks.go
+++ b/validators/blocks.go
@@ -24,6 +24,15 @@ func ValidateUpdateBlockRequest(req *notespb.UpdateBlockRequest) error {
 	)
 }
 
+func ValidateUpdateBlockIndexRequest(req *notespb.UpdateBlockIndexRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.GroupId, validation.Required),
+		validation.Field(&req.NoteId, validation.Required),
+		validation.Field(&req.BlockId, validation.Required),
+		validation.Field(&req.Index, validation.Required),
+	)
+}
+
 func ValidateDeleteBlockRequest(req *notespb.DeleteBlockRequest) error {
 	return validation.ValidateStruct(req,
 		validation.Field(&req.GroupId, validation.Required),


### PR DESCRIPTION
#### Description

Added a endpoint `UpdateBlockIndex` for updating the index the easiest way possible.

Fixes #63 

#### Changelog

- `InsertBlock` : Specify the index when you want to insert your block
- `UpdateBlock` : Update everything needed excpeted the index
- `UpdateBlockIndex` : Update only the index by the **deletion** of the block and **re insertion** of a new one with the same properties. And returns the new block message (with a new id).
- `GetNote` : Returns the notes meta info AND the blocks array in the **right order**.

Like this I don't have to keep an `index` field in my blocks.
And I don't have any logic of re-organization of the indexes when one is moved.
