### PR TITLE
feat: add accountId filter in ListActivities endpoint and mongo call,…

### DIFF
--- a/activities.go
+++ b/activities.go
@@ -28,8 +28,13 @@ func (srv *groupsAPI) ListActivities(ctx context.Context, req *notesv1.ListActiv
 		return nil, statusFromModelError(err)
 	}
 
+	// Check if user is the same than the requested AccountId
+	if token.AccountID != req.AccountId && len(req.AccountId) > 0 {
+		return nil, status.Error(codes.PermissionDenied, "The user accountId isn't the same than the accountId requested")
+	}
+
 	activities, err := srv.activities.ListActivitiesInternal(ctx,
-		&models.ManyActivitiesFilter{GroupID: req.GroupId},
+		&models.ManyActivitiesFilter{GroupID: req.GroupId, AccountID: req.AccountId},
 		&models.ListOptions{Limit: int32(req.Limit), Offset: int32(req.Offset)})
 	if err != nil {
 		return nil, statusFromModelError(err)

--- a/activities_test.go
+++ b/activities_test.go
@@ -89,9 +89,17 @@ func TestActivitiesSuite(t *testing.T) {
 		require.Equal(t, 4, len(res.Activities))
 	})
 
-	t.Run("stanger-cannot-list-activities", func(t *testing.T) {
+	t.Run("stanger-cannot-list-activities-by-group", func(t *testing.T) {
 		res, err := tu.groups.ListActivities(stranger.Context, &notesv1.ListActivitiesRequest{
 			GroupId: gabiGroup.ID,
+		})
+		require.Error(t, err)
+		require.Nil(t, res)
+	})
+
+	t.Run("stanger-cannot-list-activities-by-user", func(t *testing.T) {
+		res, err := tu.groups.ListActivities(stranger.Context, &notesv1.ListActivitiesRequest{
+			AccountId: gabiGroup.ID,
 		})
 		require.Error(t, err)
 		require.Nil(t, res)

--- a/models/activities.go
+++ b/models/activities.go
@@ -25,7 +25,8 @@ type OneActivityFilter struct {
 }
 
 type ManyActivitiesFilter struct {
-	GroupID string
+	GroupID   string
+	AccountID string
 }
 
 type Activity struct {

--- a/models/mongo/activities.go
+++ b/models/mongo/activities.go
@@ -33,9 +33,7 @@ func NewActivitiesRepository(db *mongo.Database, logger *zap.Logger) models.Acti
 func (repo *activitiesRepository) ListActivitiesInternal(ctx context.Context, filter *models.ManyActivitiesFilter, lo *models.ListOptions) ([]*models.Activity, error) {
 	activities := make([]*models.Activity, 0)
 
-	query := bson.D{
-		{Key: "groupId", Value: filter.GroupID},
-	}
+	query := getActivityQuery(filter)
 
 	err := repo.find(ctx, query, &activities, lo)
 	if err != nil {
@@ -76,4 +74,15 @@ func (repo *activitiesRepository) CreateActivityInternal(ctx context.Context, pa
 	}
 
 	return activity, nil
+}
+
+func getActivityQuery(filter *models.ManyActivitiesFilter) bson.D {
+	if filter.AccountID == "" {
+		return bson.D{
+			{Key: "groupId", Value: filter.GroupID},
+		}
+	}
+	return bson.D{
+		{Key: "accountId", Value: filter.AccountID},
+	}
 }

--- a/validators/activities.go
+++ b/validators/activities.go
@@ -1,15 +1,20 @@
 package validators
 
 import (
+	"errors"
 	notesv1 "notes-service/protorepo/noted/notes/v1"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 func ValidateListActivitiesRequest(req *notesv1.ListActivitiesRequest) error {
-	return validation.ValidateStruct(req,
-		validation.Field(&req.GroupId, validation.Required, validation.Required),
-	)
+	errorGroupId := validation.ValidateStruct(req, validation.Field(&req.GroupId, validation.Required, validation.Required))
+	errorAccountId := validation.ValidateStruct(req, validation.Field(&req.AccountId, validation.Required, validation.Required))
+
+	if errorGroupId != nil && errorAccountId != nil {
+		return errors.New("A GroupId or AccountId should be provided")
+	}
+	return nil
 }
 
 func ValidateGetActivityRequest(req *notesv1.GetActivityRequest) error {


### PR DESCRIPTION
#### Description

In order to list activities by Users :
- I've added an `accountId` field in filter of `ListActivities` endpoint and mongoDb call.
- Done a new unit test to check that a stranger can't acces to the activities of someone else
- Updated validator for `ListActivities` in order to ensure that we always have one filter, etheir `AccountId` or `GroupId`

It's also possible to request all the activities of an account into a group. You have to put the two filters `AccountId` & `GroupId`

Fixes #87 